### PR TITLE
Allow user to configure controls & interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,52 @@ For more information on farmOS, visit [farmOS.org](https://farmOS.org).
 2. Call the map creation method with the element ID: `farmOS.map.create('farm-map');`
 3. (optional) Add behaviors - see below.
 
+### Creating a Map
+
+The simplest way to create a map is to call the `create` method with an HTML
+element's ID. This will render a map with all the OpenLayers and farmOS defaults.
+However, you can also call it with an options object, as its second parameter,
+with a `controls` and/or `interactions` property. If a property is set to
+`false`, none of its corresponding default controls or interactions will be
+applied to the map. If the property is assigned to an array of OpenLayers
+controls or interactions, the defaults will be discarded and those controls or
+interactions will be used in their place. If the property is assigned to a
+callback function, that function will be called and passed the default controls
+or interactions. It must return a an array of OL controls/interactions, which
+will be attached to the map in the place of the defaults.
+
+For example:
+
+```js
+// Calling .create() with just an id renders a map with the farmOS defaults.
+const id = 'myMap';
+farmOS.map.create(id);
+
+// Passing an options object with interactions set to false will cancel the
+// interaction defaults.
+const opts1 = { interactions: false };
+farmOS.map.create(id, opts1);
+
+// An options object with an array of controls to replace the defaults.
+const opts2 = {
+  controls: [
+    new MyControl(),
+  ],
+};
+farmOS.map.create(id, opts2);
+
+// An options object with a function which alters the control defaults.
+const opts3 = {
+  controls: (defaults) => defaults.filter(def => (
+    def.constructor.name === 'Attribution'
+    )).concat([
+      new MyControl1(),
+      new MyControl2(),
+    ]),
+};
+farmOS.map.create(id, opts3);
+```
+
 ### Adding behaviors
 
 Behaviors allow you to make modifications to a map in a modular way, by defining
@@ -23,7 +69,7 @@ JavaScript functions that will run automatically when a map is created.
 
 For example:
 
-```
+```js
 (function () {
   farmOS.map.behaviors.myCustomizations = {
     attach: function (instance) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -40,8 +40,9 @@ const defaults = {
   },
 
   // Controls.
-  controls() {
-    return defaultControls().extend([
+  controls(options) {
+    // Extend the OpenLayers defaults with farmOS defaults.
+    const extendedDefaults = defaultControls().extend([
       new LayerSwitcher(),
       new FullScreen(),
       new ScaleLine(),
@@ -52,10 +53,39 @@ const defaults = {
         autoComplete: true,
       }),
     ]);
+    // If controls were set to 'false', don't attach any controls.
+    if (options === false) {
+      return [];
+    }
+    // If an array of controls was passed, use this instead of the defaults.
+    if (Array.isArray(options)) {
+      return options;
+    }
+    // If a callback function is provided, pass it the defaults
+    // and return what it evaluates to.
+    if (typeof options === 'function') {
+      return options(extendedDefaults.array_); // eslint-disable-line no-underscore-dangle
+    }
+    // Otherwise just return the defaults.
+    return extendedDefaults;
   },
 
   // Interactions.
-  interactions() {
+  interactions(options) {
+    // If interactions were set to 'false', don't attach any interactions.
+    if (options === false) {
+      return [];
+    }
+    // If an array of interactions was passed, use this instead of the defaults.
+    if (Array.isArray(options)) {
+      return options;
+    }
+    // If a callback function is provided, pass it the defaults
+    // and return what it evaluates to.
+    if (typeof options === 'function') {
+      return options(defaultInteractions().array_); // eslint-disable-line no-underscore-dangle
+    }
+    // Otherwise just return the defaults.
     return defaultInteractions();
   },
 };

--- a/src/instance.js
+++ b/src/instance.js
@@ -18,7 +18,7 @@ import defaults from './defaults';
 import styles from './styles';
 
 // Define an object that represents a single farmOS map instance.
-const createInstance = ({ target }) => ({
+const createInstance = ({ target, options }) => ({
 
   // The target element ID for the map.
   target,
@@ -27,8 +27,8 @@ const createInstance = ({ target }) => ({
   map: new Map({
     target,
     layers: defaults.layers(),
-    controls: defaults.controls(),
-    interactions: defaults.interactions(),
+    controls: defaults.controls(options.controls),
+    interactions: defaults.interactions(options.interactions),
     view: new View({
       center: [0, 0],
       zoom: 2,

--- a/src/main.js
+++ b/src/main.js
@@ -20,8 +20,8 @@ window.farmOS.map = {
 
   // Create a new farmOS map attached to a target element ID and add it to the
   // global instances array.
-  create(target) {
-    const instance = createInstance({ target });
+  create(target, options) {
+    const instance = createInstance({ target, options });
 
     // Add the instance to the array.
     this.instances.push(instance);


### PR DESCRIPTION
This allows the user to pass an options object to configure the defaults controls and/or interactions attached to the map. The control/interaction property can be a boolean, an array of OpenLayers controls or interactions, a function, or undefined.