### PR TITLE
Provide an addWKTLayer method

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ const opts3 = {
 farmOS.map.create(id, opts3);
 ```
 
+### Adding a Well Known Text (WKT) layer
+
+It is possible to add geometries in the Well Known Text format on a map instance
+by calling the `addWKTLayer` method on the instance.
+
+```js
+const wkt = "POLYGON ((-75.53643733263014 42.54424760416683, -75.5360350012779 42.54427527000766, -75.53589016199109 42.54412508386721, -75.53547173738478 42.54316467447933, -75.53547173738478 42.54301053332517, -75.53564876317976 42.54289196294764, -75.53582578897475 42.54281291590414, -75.53588747978209 42.54302634269183, -75.53643733263014 42.54424760416683))";
+myMap.addWKTLayer("my-polygon", wkt, "orange", true);
+```
+
+The first argument is a title for the layer; the second is the WKT string you'd
+like to render; the third is the stroke color of the geometry (default is 
+`"yellow"`); and the fourth is a boolean to set whether the layer is visible or
+not (default is `true`).
+
 ### Adding behaviors
 
 Behaviors allow you to make modifications to a map in a modular way, by defining

--- a/src/instance.js
+++ b/src/instance.js
@@ -8,6 +8,7 @@ import TileWMS from 'ol/source/TileWMS';
 import VectorLayer from 'ol/layer/Vector';
 import TileLayer from 'ol/layer/Tile';
 import GeoJSON from 'ol/format/GeoJSON';
+import WKT from 'ol/format/WKT';
 
 import { createEmpty as extentCreateEmpty, extend as extendExtend } from 'ol/extent';
 
@@ -53,6 +54,31 @@ const createInstance = ({ target, options }) => ({
     // Zoom to the combined extent of all sources as they are loaded.
     const self = this;
     source.on('change', () => { self.zoomToVectors(); });
+  },
+
+  // Add Well Known Text (WKT) geometry to the map.
+  addWKTLayer(title, wkt, color, visible = true) {
+    const style = styles(color);
+    const isMultipart = wkt.includes('MULTIPOINT')
+      || wkt.includes('MULTILINESTRING')
+      || wkt.includes('MULTIPOLYGON')
+      || wkt.includes('GEOMETRYCOLLECTION');
+    let feature;
+    if (isMultipart) {
+      feature = new WKT().readFeatures(wkt);
+    } else {
+      feature = new WKT().readFeature(wkt);
+    }
+    const source = new VectorSource({
+      features: [feature],
+    });
+    const layer = new VectorLayer({
+      title,
+      source,
+      style,
+      visible,
+    });
+    this.map.addLayer(layer);
   },
 
   // Add a WMS tile layer to the map.


### PR DESCRIPTION
A basic method for adding WKT geometry layers to a map, loosely based on the `addGeoJSON` and `addWMSTileLayer` methods. This contains branching logic for handling both geometry primitives and multipart geometries, because OpenLayers has different methods for each.