### PR TITLE
Add a method for destroying an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ const opts3 = {
 farmOS.map.create(id, opts3);
 ```
 
+### Tearing down a map
+
+It may be desirable to tear down a map instance when you no longer need it so
+that it can be garbage collected. To do so, you need to provide the instance's
+target id, and pass it to the `destroy` method:
+
+```js
+farmOS.map.destroy('my-map');
+```
+
 ### Adding a Well Known Text (WKT) layer
 
 It is possible to add geometries in the Well Known Text format on a map instance

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,15 @@ window.farmOS.map = {
     return instance;
   },
 
+  // Destroy a farmOS map instance and remove it from the instances array.
+  destroy(target) {
+    const i = this.targetIndex(target);
+    if (i > -1) {
+      this.instances[i].map.setTarget(null);
+      this.instances.splice(i, 1);
+    }
+  },
+
   // Attach behaviors to an instance.
   attachBehaviors(instance) {
     Object.keys(this.behaviors).forEach((key) => {


### PR DESCRIPTION
Pretty straightforward: it looks up the index for a given map instance, sets its target to `null` and then removes it from the array of instances.