### PR TITLE
Return layers and bugfix

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -63,15 +63,10 @@ const createInstance = ({ target, options }) => ({
       || wkt.includes('MULTILINESTRING')
       || wkt.includes('MULTIPOLYGON')
       || wkt.includes('GEOMETRYCOLLECTION');
-    let feature;
-    if (isMultipart) {
-      feature = new WKT().readFeatures(wkt);
-    } else {
-      feature = new WKT().readFeature(wkt);
-    }
-    const source = new VectorSource({
-      features: [feature],
-    });
+    const features = isMultipart
+      ? new WKT().readFeatures(wkt)
+      : [new WKT().readFeature(wkt)];
+    const source = new VectorSource({ features });
     const layer = new VectorLayer({
       title,
       source,

--- a/src/instance.js
+++ b/src/instance.js
@@ -54,6 +54,8 @@ const createInstance = ({ target, options }) => ({
     // Zoom to the combined extent of all sources as they are loaded.
     const self = this;
     source.on('change', () => { self.zoomToVectors(); });
+
+    return layer;
   },
 
   // Add Well Known Text (WKT) geometry to the map.
@@ -74,6 +76,7 @@ const createInstance = ({ target, options }) => ({
       visible,
     });
     this.map.addLayer(layer);
+    return layer;
   },
 
   // Add a WMS tile layer to the map.
@@ -88,6 +91,7 @@ const createInstance = ({ target, options }) => ({
       visible,
     });
     this.map.addLayer(layer);
+    return layer;
   },
 
   // Zoom to all vector sources in the map.


### PR DESCRIPTION
This resolves #27, regarding layers.

The bugfix addresses a problem with the way multipart and single geometries are encoded as features by OL. They each have their own `read*` method, which was previously addressed, but also, multipart features cannot be wrapped in an array, because they're already considered a collection. I hadn't tested this thoroughly before, but have since adding multipart geometries to the client.

@mstenta, let me know if you'd prefer this as 2 separate PR's.