### PR TITLE
Fix missing projection opts in addWKTLayer

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -65,9 +65,13 @@ const createInstance = ({ target, options }) => ({
       || wkt.includes('MULTILINESTRING')
       || wkt.includes('MULTIPOLYGON')
       || wkt.includes('GEOMETRYCOLLECTION');
+    const opts = {
+      dataProjection: 'EPSG:4326',
+      featureProjection: 'EPSG:3857',
+    };
     const features = isMultipart
-      ? new WKT().readFeatures(wkt)
-      : [new WKT().readFeature(wkt)];
+      ? new WKT().readFeatures(wkt, opts)
+      : [new WKT().readFeature(wkt, opts)];
     const source = new VectorSource({ features });
     const layer = new VectorLayer({
       title,


### PR DESCRIPTION
This was causing WKT layers to be sized at nanometer scale at 0 lat, 0 long. Resolves #30.