### PR TITLE
Add features to drawing layer when drawing is enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,12 @@ const myMap = farmOS.map.create("map");
 myMap.enableDraw();
 ```
 
-A new drawing layer will be automatically created and added to the map.
+A new drawing layer will be automatically created and added to the map, unless you provide a vector layer as an option:
+
+```js
+const drawingLayer = myMap.addLayer('wkt', wktString);
+myMap.enableDraw({ layer: drawingLayer });
+```
 
 #### Importing and exporting WKT / GeoJSON
 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,13 @@ const drawingLayer = myMap.addLayer('wkt', wktString);
 myMap.enableDraw({ layer: drawingLayer });
 ```
 
-#### Importing and exporting WKT / GeoJSON
+#### Exporting WKT / GeoJSON
 
-There are some methods on the Edit control for importing and exporting
+There are some methods on the Edit control for exporting
 geometries in Well Known Text (WKT) and GeoJSON format:
 
 - `getWKT` / `getGeoJSON` - returns a string containing all the features on the
   drawing layer.
-- `setWKT` / `setGeoJSON` - takes a string and adds its features to the drawing
-  layer. This replaces any existing features in the layer.
 - `wktOn` / `geoJSONOn` - add event listeners for particular editing
   interactions. See example below:
 

--- a/src/control/Edit/Edit.js
+++ b/src/control/Edit/Edit.js
@@ -608,26 +608,6 @@ class Edit extends Control {
   }
 
   /**
-   * Setter which accepts features in Well Known Text (WKT) format and sets them
-   * as the drawing layer's source features. This will clear all current
-   * features first.
-   * @param {string} wktString A string of WKT.
-   * @api
-   */
-  setWKT(wktString) {
-    const source = this.layer.getSource();
-    source.clear();
-    const isMultipart = wktString.includes('MULTIPOINT')
-      || wktString.includes('MULTILINESTRING')
-      || wktString.includes('MULTIPOLYGON')
-      || wktString.includes('GEOMETRYCOLLECTION');
-    const features = isMultipart
-      ? new WKT({ splitCollection: true }).readFeatures(wktString, projection)
-      : [new WKT().readFeature(wktString, projection)];
-    source.addFeatures(features);
-  }
-
-  /**
    * Getter that returns the geometry of all features in the drawing layer in
    * GeoJSON format.
    * @api
@@ -635,20 +615,6 @@ class Edit extends Control {
   getGeoJSON() {
     const features = this.layer.getSource().getFeatures();
     return new GeoJSON().writeFeatures(features, projection);
-  }
-
-  /**
-   * Setter which accepts features in GeoJSON format and sets them as the
-   * drawing layer's source features. This will clear all current features
-   * first.
-   * @param {string} geoJSONString A string of GeoJSON.
-   * @api
-   */
-  setGeoJSON(geoJSONString) {
-    const source = this.layer.getSource();
-    source.clear();
-    const features = new GeoJSON().readFeatures(geoJSONString, projection);
-    source.addFeatures(features);
   }
 
   /**

--- a/src/instance/methods/edit.js
+++ b/src/instance/methods/edit.js
@@ -4,7 +4,7 @@ import Edit from '../../control/Edit/Edit';
 /**
  * Enable the drawing controls in the map.
  */
-export default function enableDraw() {
+export default function enableDraw({ layer } = {}) {
 
   // Create a drawing layer.
   const opts = {
@@ -12,14 +12,14 @@ export default function enableDraw() {
     group: 'Editable layers',
     color: 'orange',
   };
-  const layer = this.addLayer('vector', opts);
+  const drawingLayer = layer || this.addLayer('vector', opts);
 
   // Get the units from instance options.
   const units = (this.options.units === 'us') ? 'us' : 'metric';
 
   // Create the Edit control and add it to the map.
   // Make it available at instance.edit.
-  this.edit = new Edit({ layer, units });
+  this.edit = new Edit({ layer: drawingLayer, units });
   this.map.addControl(this.edit);
 
   // Enable geometry measurements.


### PR DESCRIPTION
This fixes a breaking change that effected Field Kit, where setting the WKT on the drawing layer with `setWKT` was destroying event listeners necessary for the popups and for the `wktOn` method. So instead of setting the WKT with a setter, we're allowing the consumer to pass in an optional layer parameter when calling `enableDraw`.

We're also removing the `setWKT` and `setGeoJSON` methods because they were destructive (eg, they called `source.clear()` to overwrite the features on the layer), and because no applications were using those methods once they were removed from Field Kit. If we have a need in the future for some sort of setter, we'll want to rethink the design so it's not destructive.

The docs have been updated to reflect these changes.