### PR TITLE
Implement basic 'arcgis-tile' layer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ const wmsOpts = {
 };
 const wmsLayer = myMap.addLayer('wms', wmsOpts);
 
+// Adding a ArcGIS MapServer tile layer.
+const arcGISTileOpts = {
+  title: 'StateCityHighway_USA', // defaults to 'arcgis-tile'
+  url: 'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer', // REQUIRED!
+  visible: true, // defaults to true
+  base: false // defaults to false
+};
+const arcGISTileLayer = myMap.addLayer('arcgis-tile', arcGISTileOpts);
+
 // Adding an XYZ layer.
 const xyzOpts = {
   title: 'mapbox', // defaults to 'xyz'

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -81,15 +81,17 @@ function addGeoJSONLayer({
 
 // Add a Tile ArcGIS MapServer layer to the map.
 function addTileArcGISMapServerLayer({
-  title = 'arcgis-tile', url, color = 'orange', visible = true,
+  title = 'arcgis-tile', url, params, visible = true, base = false,
 }) {
-  const style = styles(color);
-  const source = new TileArcGISRest({ url });
+  const source = new TileArcGISRest({
+    url,
+    params,
+  });
   const layer = new TileLayer({
     title,
     source,
-    style,
     visible,
+    type: base ? 'base' : 'normal',
   });
   return layer;
 }

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -1,6 +1,7 @@
 // Import source types, layer types, and formats.
 import VectorSource from 'ol/source/Vector';
 import Cluster from 'ol/source/Cluster';
+import TileArcGISRest from 'ol/source/TileArcGISRest';
 import TileWMS from 'ol/source/TileWMS';
 import XYZ from 'ol/source/XYZ';
 import LayerGroup from 'ol/layer/Group';
@@ -70,6 +71,21 @@ function addGeoJSONLayer({
   const format = new GeoJSON();
   const source = new VectorSource({ url, format });
   const layer = new VectorLayer({
+    title,
+    source,
+    style,
+    visible,
+  });
+  return layer;
+}
+
+// Add a Tile ArcGIS MapServer layer to the map.
+function addTileArcGISMapServerLayer({
+  title = 'arcgis-tile', url, color = 'orange', visible = true,
+}) {
+  const style = styles(color);
+  const source = new TileArcGISRest({ url });
+  const layer = new TileLayer({
     title,
     source,
     style,
@@ -165,6 +181,12 @@ export default function addLayer(type, opts = {}) {
       throw new Error('Missing a GeoJSON url.');
     }
     layer = addGeoJSONLayer(opts);
+  }
+  if (type.toLowerCase() === 'arcgis-tile') {
+    if (!opts.url) {
+      throw new Error('Missing a ArcGIS MapServer url.');
+    }
+    layer = addTileArcGISMapServerLayer(opts);
   }
   if (type.toLowerCase() === 'wkt') {
     if (!opts.wkt) {


### PR DESCRIPTION
Testing with the following added to the generated `build/index.html`;

```javascript
       // myMap.addBehavior("google");
+
+      // Adding a ArcGIS MapServer tile layer.
+      const arcGISTileOpts = {
+          title: 'ESRI_StateCityHighway_USA', // defaults to 'arcgis-tile'
+          url: 'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Specialty/ESRI_StateCityHighway_USA/MapServer', // REQUIRED!
+          visible: true, // defaults to true
+          base: false // defaults to false
+      };
+      const arcGISTileLayer = myMap.addLayer('arcgis-tile', arcGISTileOpts);
 
       myMap.addBehavior("edit");
```

Yields;

![image](https://user-images.githubusercontent.com/30754460/78374633-bfa8dd00-7580-11ea-9ab8-1b467cf4eaff.png)
