### PR TITLE
Add support for style functions #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,23 @@ const opts = {
 const layer = myMap.addLayer('geojson', opts);
 ```
 
+#### Layer styles
+
+By default all vector layers are styled with the stoke of a given `color`
+(see [available colors](src/styles/index.js)).
+
+For more complex styles, the `styleFunction` option allows styles to be
+defined based on a `feature` and `resolution`
+([StyleFunction docs.](https://openlayers.org/en/latest/apidoc/module-ol_style_Style.html#~StyleFunction)) 
+In addition to the `feature` and `resolution`, farmOS-map calls `styleFunction`
+with an additional `style` parameter. This parameters makes all of the 
+`ol.style` classes available to other JavaScript modules without requiring
+them to bundle `ol.style` themselves.
+
+This makes it possible to style farmOS areas based on properties included in
+`farm/areas/geojson` such as the area `id`. Clusters are dispalyed in farmOS
+using a [`clusterStyle`](src/styles/index.js) function.
+
 #### Attribution
 
 Layer attribution can be added by passing an `attribution` option to the

--- a/README.md
+++ b/README.md
@@ -238,9 +238,15 @@ with an additional `style` parameter. This parameters makes all of the
 `ol.style` classes available to other JavaScript modules without requiring
 them to bundle `ol.style` themselves.
 
-This makes it possible to style farmOS areas based on properties included in
-`farm/areas/geojson` such as the area `id`. Clusters are dispalyed in farmOS
-using a [`clusterStyle`](src/styles/index.js) function.
+This makes it possible to style farmOS areas based on properties included in 
+their GeoJSON. Cluster layers use a pre-defined style function, but it can be 
+overridden using the same `styleFunction` parameter.
+
+An [example `styleFunction`](https://gist.github.com/paul121/d8a7e7441df39b15a02042175c9805fe)
+that uses both the resolution and a feature's `id` property.
+
+**NOTE:** For performance it is important to implement a style cache when 
+using a custom `styleFunction` ([example](http://openlayersbook.github.io/ch06-styling-vector-layers/example-06.html))
 
 #### Attribution
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,20 @@ const layer = myMap.addLayer('geojson', opts);
 
 #### Layer styles
 
-By default all vector layers are styled with the stoke of a given `color`
-(see [available colors](src/styles/index.js)).
+By default all vector layers are styled with the stoke of a given `color`.
+Available colors:
+```js
+const colors = {
+  blue: 'rgba(51,153,255,1)',
+  green: 'rgba(51,153,51,1)',
+  darkgreen: 'rgba(51,153,51,1)',
+  grey: 'rgba(204,204,204,0.7)',
+  orange: 'rgba(255,153,51,1)',
+  red: 'rgba(204,0,0,1)',
+  purple: 'rgba(204,51,102,1)',
+  yellow: 'rgba(255,255,51,1)',
+};
+```
 
 For more complex styles, the `styleFunction` option allows styles to be
 defined based on a `feature` and `resolution`

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const layer = myMap.addLayer('geojson', opts);
 
 #### Layer styles
 
-By default all vector layers are styled with the stoke of a given `color`.
+By default all vector layers are styled with the stroke of a given `color`.
 Available colors:
 ```js
 const colors = {
@@ -234,7 +234,7 @@ For more complex styles, the `styleFunction` option allows styles to be
 defined based on a `feature` and `resolution`
 ([StyleFunction docs.](https://openlayers.org/en/latest/apidoc/module-ol_style_Style.html#~StyleFunction)) 
 In addition to the `feature` and `resolution`, farmOS-map calls `styleFunction`
-with an additional `style` parameter. This parameters makes all of the 
+with an additional `style` parameter. This parameter makes all of the 
 `ol.style` classes available to other JavaScript modules without requiring
 them to bundle `ol.style` themselves.
 

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -15,7 +15,7 @@ import { setWithCredentials } from 'ol/featureloader';
 
 // Import styles.
 import * as Style from 'ol/style';
-import styles, { clusterStyle } from '../../styles';
+import colorStyles, { clusterStyle } from '../../styles';
 
 // Import the default projection configuration
 import projection from '../../projection';
@@ -33,7 +33,7 @@ function addVectorLayer({
 }) {
   const style = styleFunction
     ? (feature, resolution) => styleFunction(feature, resolution, Style)
-    : styles(color);
+    : colorStyles(color);
   const attributions = [attribution];
   const source = new VectorSource({
     attributions,
@@ -78,7 +78,7 @@ function addGeoJSONLayer({
 }) {
   const style = styleFunction
     ? (feature, resolution) => styleFunction(feature, resolution, Style)
-    : styles(color);
+    : colorStyles(color);
   const format = new GeoJSON();
   const attributions = [attribution];
   let source;
@@ -129,7 +129,7 @@ function addWKTLayer({
 }) {
   const style = styleFunction
     ? (feature, resolution) => styleFunction(feature, resolution, Style)
-    : styles(color);
+    : colorStyles(color);
   const isMultipart = wkt.includes('MULTIPOINT')
     || wkt.includes('MULTILINESTRING')
     || wkt.includes('MULTIPOLYGON')

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -14,6 +14,7 @@ import WKT from 'ol/format/WKT';
 import { setWithCredentials } from 'ol/featureloader';
 
 // Import styles.
+import * as Style from 'ol/style';
 import styles, { clusterStyle } from '../../styles';
 
 // Import the default projection configuration
@@ -70,9 +71,11 @@ function addClusterLayer({
 
 // Add a GeoJSON feature layer to the map.
 function addGeoJSONLayer({
-  title = 'geojson', url = '', geojson = {}, color = 'orange', visible = true, attribution = '',
+  title = 'geojson', url = '', geojson = {}, color = 'orange', styleFunction = null, visible = true, attribution = '',
 }) {
-  const style = styles(color);
+  const style = styleFunction
+  ? (feature, resolution) => styleFunction(feature, resolution, Style)
+  : styles(color);
   const format = new GeoJSON();
   const attributions = [attribution];
   let source;

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -49,8 +49,9 @@ function addVectorLayer({
 
 // Add a cluster layer to the map.
 function addClusterLayer({
-  title = 'cluster', url, visible = true, attribution = '',
+  title = 'cluster', url, styleFunction = clusterStyle, visible = true, attribution = '',
 }) {
+  const style = (feature, resolution) => styleFunction(feature, resolution, Style);
   const format = new GeoJSON();
   const attributions = [attribution];
   const centroidSource = new VectorSource({
@@ -65,7 +66,7 @@ function addClusterLayer({
   const clusterLayer = new VectorLayer({
     title,
     source: clusterSource,
-    style: clusterStyle,
+    style,
     visible,
   });
   return clusterLayer;

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -124,9 +124,11 @@ function addTileArcGISMapServerLayer({
 
 // Add Well Known Text (WKT) geometry to the map.
 function addWKTLayer({
-  title = 'wkt', wkt, color = 'orange', visible = true, attribution = '',
+  title = 'wkt', wkt, color = 'orange', styleFunction = null, visible = true, attribution = '',
 }) {
-  const style = styles(color);
+  const style = styleFunction
+    ? (feature, resolution) => styleFunction(feature, resolution, Style)
+    : styles(color);
   const isMultipart = wkt.includes('MULTIPOINT')
     || wkt.includes('MULTILINESTRING')
     || wkt.includes('MULTIPOLYGON')

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -29,9 +29,11 @@ setWithCredentials(true);
 
 // Add a Vector layer to the map.
 function addVectorLayer({
-  title = 'vector', color = 'orange', visible = true, attribution = '',
+  title = 'vector', color = 'orange', styleFunction = null, visible = true, attribution = '',
 }) {
-  const style = styles(color);
+  const style = styleFunction
+    ? (feature, resolution) => styleFunction(feature, resolution, Style)
+    : styles(color);
   const attributions = [attribution];
   const source = new VectorSource({
     attributions,

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -74,8 +74,8 @@ function addGeoJSONLayer({
   title = 'geojson', url = '', geojson = {}, color = 'orange', styleFunction = null, visible = true, attribution = '',
 }) {
   const style = styleFunction
-  ? (feature, resolution) => styleFunction(feature, resolution, Style)
-  : styles(color);
+    ? (feature, resolution) => styleFunction(feature, resolution, Style)
+    : styles(color);
   const format = new GeoJSON();
   const attributions = [attribution];
   let source;

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -17,7 +17,7 @@ const colors = {
 };
 
 // Returns an OpenLayers Style for a given color.
-const styles = (color) => {
+const colorStyles = (color) => {
   const rgba = colors[color] ? colors[color] : colors.yellow;
   const stroke = new Stroke({
     color: rgba,
@@ -37,7 +37,7 @@ const styles = (color) => {
     image,
   });
 };
-export default styles;
+export default colorStyles;
 
 // Provide a standard cluster style.
 const styleCache = {};

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -5,6 +5,7 @@ import Circle from 'ol/style/Circle';
 import Text from 'ol/style/Text';
 
 // Define the available colors and their associated RGBA values.
+// Colors are listed in README.md documentation, keep these in sync.
 const colors = {
   blue: 'rgba(51,153,255,1)',
   green: 'rgba(51,153,51,1)',


### PR DESCRIPTION
Finally getting around to implementing support for a `styleFunction` as we discussed in #72 .

This is really a simple change. It just adds `styleFunction` as another parameter to `addGeoJSONLayer`.

Right now this makes the most sense for GeoJSON layers because these features can have additional properties. This is what farmOS uses to link the feature to the `area_id`. But I'm curious if we should add this functionality for other layer types, too. Although a WMS doesn't allow defining properties, the style function can still be useful for styling at different resolutions. I believe resolution would be applicable for all other layer types.

Any thoughts on adding this to other layer types?

I generated an example with a style function that colors GeoJSON features different colors based on an odd or even `id` property. The alpha value changes with the resolution.

[Example code](https://gist.github.com/paul121/d8a7e7441df39b15a02042175c9805fe)

[Demo](https://user-images.githubusercontent.com/3116995/83806810-e8c01980-a666-11ea-9761-ac427a9db98b.gif) (the GIF is rather distracting embedded on this page)