### PR TITLE
Handle formulas/errors in Snapping Grid dimensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,19 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@emmetio/math-expression": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/math-expression/-/math-expression-1.0.4.tgz",
+      "integrity": "sha512-1m7y8/VeXCAfgFoPGTerbqCIadApcIINujd3TaM/LRLPPKiod8aT1PPmh542spnsUSsSnZJjbuF7xiO4WFA42g==",
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/scanner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA=="
+    },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -4035,11 +4048,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
-    },
-    "math-expression-evaluator": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
-      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4036,6 +4036,11 @@
       "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
       "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
     },
+    "math-expression-evaluator": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
+      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "math-expression-evaluator": "^1.2.22",
+    "@emmetio/math-expression": "^1.0.4",
     "ol": "^6.4.0",
     "ol-geocoder": "^4.0.0",
     "ol-grid": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "math-expression-evaluator": "^1.2.22",
     "ol": "^6.4.0",
     "ol-geocoder": "^4.0.0",
     "ol-grid": "^1.1.4",

--- a/src/control/SnappingGrid/SnappingGrid.css
+++ b/src/control/SnappingGrid/SnappingGrid.css
@@ -38,18 +38,23 @@
 .ol-snapgrid.ol-control input {
   display: inline-block;
   width: 4em;
-  padding: 0;
   margin: 0;
+  border: 1px solid;
+  padding: 3px;
+}
+
+.ol-snapgrid.ol-control input:focus {
+  outline: 0;
+}
+
+.ol-snapgrid.ol-control input.dim-input-err {
+  border-color: red;
 }
 
 .ol-snapgrid.ol-control span.timesSymbol {
   display: inline-block;
   padding: 0 0.5em 0 0.5em;
   margin: 0;
-}
-
-.ol-snapgrid.ol-control input:focus {
-  outline: 0;
 }
 
 .ol-snapgrid.ol-control button.enable {

--- a/src/control/SnappingGrid/SnappingGrid.js
+++ b/src/control/SnappingGrid/SnappingGrid.js
@@ -19,7 +19,7 @@ import VectorSource from 'ol/source/Vector';
  */
 import Grid from 'ol-grid/dist/ol-grid.cjs';
 
-import mexp from 'math-expression-evaluator';
+import evaluate from '@emmetio/math-expression';
 
 import forEachLayer from '../../utils/forEachLayer';
 
@@ -173,8 +173,8 @@ class SnappingGrid extends Control {
 
     function multibindEventListeners(elements, eventHandlers) {
       elements.forEach((elem) => {
-        Object.entries(eventHandlers).forEach((eventType, eventHandler) => {
-          elem.addEventListener(eventType, eventHandler.bind(self), false);
+        Object.keys(eventHandlers).forEach((eventType) => {
+          elem.addEventListener(eventType, eventHandlers[eventType].bind(self), false);
         });
       });
     }
@@ -198,7 +198,7 @@ class SnappingGrid extends Control {
     ], {
       blur: self.handleDimInputBlur,
       focus: self.handleDimInputFocus,
-      keydown: self.handleDimInputEnterKey,
+      keydown: SnappingGrid.handleDimInputEnterKey,
     });
 
   }
@@ -270,7 +270,7 @@ class SnappingGrid extends Control {
 
     if (rawValue[0] === '=') {
       try {
-        dimInputEl.value = mexp.eval(rawValue.substring(1)).toFixed(4);
+        dimInputEl.value = evaluate(rawValue.substring(1)).toFixed(4);
       } catch (err) {
         // Swallow errors here since they are handled in getDimFromInputElem for display to the user
       }
@@ -600,7 +600,7 @@ class SnappingGrid extends Control {
 
       let value;
       if (rawValue[0] === '=') {
-        value = mexp.eval(rawValue.substring(1));
+        value = evaluate(rawValue.substring(1));
       } else {
         value = parseFloat(rawValue);
       }


### PR DESCRIPTION
**Why?** Avoid the need to use an external calculator for computing even spacing. e.g. if I had a 50' bed with 120 rows, I could type `=(50 * 12) / 120` directly in the dimension input box to calculate the row spacing of 5" per row.

![Peek 2020-09-10 09-38](https://user-images.githubusercontent.com/30754460/92764687-7cca0d00-f349-11ea-89a8-40d4b5a6a4cc.gif)

*Note the ~~10~~ now 4 KiB size increase. I'm not sure what the criteria for inclusion/exclusion of features should be for farmOS-map...*