### PR TITLE
Include 'elm-pep' pointer events polyfill for old browsers. #88

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "elm-pep": "^1.0.6",
     "ol": "^6.4.0",
     "ol-geocoder": "^4.0.0",
     "ol-grid": "^1.1.4",

--- a/src/instance/defaults.js
+++ b/src/instance/defaults.js
@@ -1,3 +1,7 @@
+// Include pointer events polyfill for old browsers.
+// See https://caniuse.com/#feat=pointer
+import 'elm-pep';
+
 // Import OL layer types.
 import LayerGroup from 'ol/layer/Group';
 import TileLayer from 'ol/layer/Tile';

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,7 @@
+// Include pointer events polyfill for old browsers.
+// See https://caniuse.com/#feat=pointer
+import 'elm-pep';
+
 // Import farmOS map instance factory function.
 import createInstance from './instance/instance';
 


### PR DESCRIPTION
Only adds 2kiB, seems safe to include the polyfill in `main.js` so we know it is always included? I believe this would need to be included for controls, interactions & behaviors as they all might provide pointer events and be effected. So perhaps it would be better to include the polyfill in `defaults.js`?

I'm not too familiar with polyfills & unsure what is best! I'll add a commit for both of those options, can include either one.

Before:
```
Hash: 2c651843bac22a73b9e8
Version: webpack 4.44.0
Time: 5846ms
Built at: 09/19/2020 11:52:18 AM
        Asset      Size  Chunks                    Chunk Names
farmOS-map.js   541 KiB       0  [emitted]  [big]  main
   index.html  1.06 KiB          [emitted]         
    mapbox.js  13.4 KiB          [emitted] 
```

After:
```
Hash: 3c160e4130076d992653
Version: webpack 4.44.0
Time: 1528ms
Built at: 09/19/2020 11:51:14 AM
        Asset      Size  Chunks                    Chunk Names
farmOS-map.js   543 KiB       0  [emitted]  [big]  main
   index.html  1.06 KiB          [emitted]         
    mapbox.js  13.4 KiB          [emitted]        
```