### PR TITLE
Add support for customizing layer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,35 @@ const opts = {
 const layer = myMap.addLayer('geojson', opts);
 ```
 
+Layer groups that are created automatically will be created with default
+settings. If you need more control over layer groups, they can be added to
+the map by using the `addLayer` method with the `group` layer type. Layer
+groups can be nested in other layer groups by providing the `group` option.
+To ensure other layers are included in your layer group make sure to add it
+to the map before other layers that should be included.
+
+The `ol-layerswitcher` [examples](https://github.com/walkermatt/ol-layerswitcher#examples)
+that demonstrate all of the available layer group options.
+
+```js
+// Adding a Layer Group
+const groupOpts = {
+  title: 'Child group', // required
+  fold: false, // defaults to false
+  combine: false, // defaults to false
+  group: 'Parent', // include in the "Parent" layer group
+}
+const layerGroup = myMap.addLayer('group', groupOpts);
+
+// Adding a vector layer to the 'Child group'
+const vectorOpts = {
+  title: 'Drawing',
+  color: 'orange',
+  group: 'Child group'
+};
+const vectorLayer = myMap.addLayer('vector', vectorOpts);
+```
+
 #### Layer styles
 
 By default all vector layers are styled with the stroke of a given `color`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Available properties include:
 
 - `units` - The system of measurement to use. Should be either `metric` or `us`.
   Defaults to `metric`.
+- `layerSwitcher` - An object with options for the `LayerSwitcher` control.
+  See the `ol-layerswitcher` [documentation](https://github.com/walkermatt/ol-layerswitcher#layerswitcher).
 - `controls` - See below.
 - `interactions` - See below.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ol": "^6.4.0",
     "ol-geocoder": "^4.0.0",
     "ol-grid": "^1.1.4",
-    "ol-layerswitcher": "^3.6.0",
+    "ol-layerswitcher": "^3.7.0",
     "ol-popup": "^4.0.0",
     "olgm": "github:mstenta/ol3-google-maps#farmOS-map"
   }

--- a/src/instance/defaults.js
+++ b/src/instance/defaults.js
@@ -60,7 +60,7 @@ const defaults = {
 
     // Define default farmOS controls.
     const farmMapDefaults = [
-      new LayerSwitcher(),
+      new LayerSwitcher(options.layerSwitcher),
       new FullScreen(),
       new Rotate({ autoHide: false }),
       new ScaleLine({ units: options.units }),

--- a/src/instance/methods/layer.js
+++ b/src/instance/methods/layer.js
@@ -209,6 +209,12 @@ export function getLayerByName(name, optlayers = null) {
 // Add a layer to the map by its type.
 export default function addLayer(type, opts = {}) {
   let layer;
+  if (type.toLowerCase() === 'group') {
+    if (!opts.title) {
+      throw new Error('Missing a Layer Group title.');
+    }
+    layer = new LayerGroup(opts);
+  }
   if (type.toLowerCase() === 'vector') {
     layer = addVectorLayer(opts);
   }


### PR DESCRIPTION
Improvements to `ol-layerswitcher` integration:
  - Bump to latest release, adds some new features: https://github.com/walkermatt/ol-layerswitcher/blob/master/CHANGELOG.md
  - Allow `opts.layerSwitcher` to be specified and passed on to configure LayerSwitcher

Adds a `group` layer type:
  - `map.addLayer('group', opts);`
  - Allows more control over LayerGroups that are added
  - LayerSwitcher attributes can be defined in the group `opts` (`fold`, `combine`, etc)

This doesn't break existing functionality with groups. It actually allows a group to specify a parent group. The parent will be auto-generated if it doesn't exist.


