### PR TITLE
Include d3-scale-chromatic in farmOS-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,18 +247,21 @@ const vectorLayer = myMap.addLayer('vector', vectorOpts);
 #### Layer styles
 
 By default all vector layers are styled with the stroke of a given `color`.
-Available colors:
+Available colors are derived from the [Tableau 10 scheme](https://github.com/d3/d3-scale-chromatic#schemeTableau10):
 
 ```js
-const colors = {
-  blue: 'rgba(51,153,255,1)',
-  green: 'rgba(51,153,51,1)',
+const defaultColors = {
+  blue: schemeTableau10[0],
+  orange: schemeTableau10[1],
+  red: schemeTableau10[2],
+  lightblue: schemeTableau10[3],
+  green: schemeTableau10[4],
   darkgreen: 'rgba(51,153,51,1)',
-  grey: 'rgba(204,204,204,0.7)',
-  orange: 'rgba(255,153,51,1)',
-  red: 'rgba(204,0,0,1)',
-  purple: 'rgba(204,51,102,1)',
-  yellow: 'rgba(255,255,51,1)',
+  yellow: schemeTableau10[5],
+  purple: schemeTableau10[6],
+  pink: schemeTableau10[7],
+  brown: schemeTableau10[8],
+  grey: schemeTableau10[9],
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "d3-scale": "^3.2.3",
+    "d3-scale-chromatic": "^2.0.0",
     "ol": "^6.4.0",
     "ol-geocoder": "^4.0.0",
     "ol-grid": "^1.1.4",

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,9 @@
 // Import farmOS map instance factory function.
 import createInstance from './instance/instance';
 
+// Import colors.
+import { colors } from './styles';
+
 // Import farmOS-map CSS.
 import './styles.css';
 
@@ -61,4 +64,6 @@ window.farmOS.map = {
   targetIndex(target) {
     return this.instances.findIndex(instance => instance.target === target);
   },
+
+  colors,
 };

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -17,14 +17,17 @@ import {
 // Define the available colors and their associated RGBA values.
 // Colors are listed in README.md documentation, keep these in sync.
 const defaultColors = {
-  blue: 'rgba(51,153,255,1)',
-  green: 'rgba(51,153,51,1)',
+  blue: schemeTableau10[0],
+  orange: schemeTableau10[1],
+  red: schemeTableau10[2],
+  lightblue: schemeTableau10[3],
+  green: schemeTableau10[4],
   darkgreen: 'rgba(51,153,51,1)',
-  grey: 'rgba(204,204,204,0.7)',
-  orange: 'rgba(255,153,51,1)',
-  red: 'rgba(204,0,0,1)',
-  purple: 'rgba(204,51,102,1)',
-  yellow: 'rgba(255,255,51,1)',
+  yellow: schemeTableau10[5],
+  purple: schemeTableau10[6],
+  pink: schemeTableau10[7],
+  brown: schemeTableau10[8],
+  grey: schemeTableau10[9],
 };
 
 // Returns an OpenLayers Style for a given color.

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -6,6 +6,7 @@ import Text from 'ol/style/Text';
 
 // Import d3 color scale functions.
 import { scaleSequential, scaleOrdinal } from 'd3-scale';
+import schemeGenerator from 'd3-scale-chromatic/src/colors';
 import {
   schemeTableau10,
   interpolateRdYlGn,
@@ -80,6 +81,7 @@ export function clusterStyle(feature) {
 export const colors = {
   scaleOrdinal,
   scaleSequential,
+  schemeGenerator,
   schemeTableau10,
   interpolateRdYlGn,
   schemeRdYlGn,

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -4,9 +4,18 @@ import Stroke from 'ol/style/Stroke';
 import Circle from 'ol/style/Circle';
 import Text from 'ol/style/Text';
 
+// Import d3 color scale functions.
+import { scaleSequential, scaleOrdinal } from 'd3-scale';
+import {
+  schemeTableau10,
+  interpolateRdYlGn,
+  schemeRdYlGn,
+  interpolateViridis,
+} from 'd3-scale-chromatic';
+
 // Define the available colors and their associated RGBA values.
 // Colors are listed in README.md documentation, keep these in sync.
-const colors = {
+const defaultColors = {
   blue: 'rgba(51,153,255,1)',
   green: 'rgba(51,153,51,1)',
   darkgreen: 'rgba(51,153,51,1)',
@@ -19,7 +28,7 @@ const colors = {
 
 // Returns an OpenLayers Style for a given color.
 const colorStyles = (color) => {
-  const rgba = colors[color] ? colors[color] : colors.yellow;
+  const rgba = defaultColors[color] ? defaultColors[color] : defaultColors.yellow;
   const stroke = new Stroke({
     color: rgba,
     width: 2,
@@ -67,3 +76,12 @@ export function clusterStyle(feature) {
   }
   return style;
 }
+
+export const colors = {
+  scaleOrdinal,
+  scaleSequential,
+  schemeTableau10,
+  interpolateRdYlGn,
+  schemeRdYlGn,
+  interpolateViridis,
+};


### PR DESCRIPTION
**Why**

The [d3-scale-chromatic](https://github.com/d3/d3-scale-chromatic) library provides great color schemes. [d3-scale](https://github.com/d3/d3-scale) makes it easy to map color schemes to continuous or ordinal data sets. These, combined with the OL `styleFunction`, make it pretty easy to apply a color scheme against a map layer's features!

Consider this a future proposal to farmOS-map... I don't think we have a good use for this in farmOS core right now, but really think we will in the future. It would be super handy for contrib modules/map behaviors, but understand if that isn't sufficient reason to include :-)

**Changes**
- Include a few "standard" schemes from d3-scale-chromatic:
  - [schemeTableau10](https://github.com/d3/d3-scale-chromatic#schemeTableau10): A thoughtfully designed color scheme that is robust & user friendly: https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782
  - [interpolateRdYlGn](https://github.com/d3/d3-scale-chromatic#interpolateRdYlGn): The common red-yellow-green color scheme.
  - [interpolateViridis](https://github.com/d3/d3-scale-chromatic#interpolateViridis): A commonly used color scheme - "pretty, better represent your data, easier to read by those with colorblindness, and print well in grey scale" - https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html
- Change the default farmOS-map colors to be derived from schemeTablea10. The existing colors map over quite well, making a few new colors available. The only exception is that there is not a `darkgreen` in the new set. TBH I haven't tested this scheme with farmOS-map running in farmOS! I like the idea of moving to something that is a bit more standard, but maybe it won't fit very well!
- Include d3.scaleSequential and d3.scaleOrdinal to support building scales from d3-scale-chromatic definitions
- Include the d3-scale-chromatic `colors` helper function as `schemeGenerator` which allows you to create custom color schemes as a string of hex codes, the same format as others!:

```js
// Custom red + green color scheme, only consists of two colors.
const colorsRdGn = farmOS.map.colors.schemeGenerator('A4243B44CF6C');
const scale = farmOS.map.colors.scaleSequential(colorsRdGn);
```

- Adds 25 KiB:
Before: ` farmOS-map.js   543 KiB       0  [emitted]  [big]  main`
After: `farmOS-map.js   568 KiB       0  [emitted]  [big]  main`

**Motivation**
For farmOS core this could be useful for mapping asset types (ordinal) to different colors (although this might be challenging since new asset types can be added, modularity, etc..)

But where this really becomes useful is for creating "heat maps". As an example, I'm currently working on a behavior that styles the areas on a map by different attributes (ordinal: plant type, crop family, continuous: # of activity logs).

Right now it's possible to do all of this by adding a layer and specifying a `styleFunction` that styles each feature accordingly. It just requires implementing color scheme + color scale logic myself OR including/packaging d3-scale and d3-scale-chromatic with my behavior. I feel that this would be a worthwhile addition to farmOS-map, especially thinking ahead to custom "reports" and other advanced UI pieces that could benefit from some advanced style rendering


