### PR TITLE
Set max-height to scroll the layer switcher

### DIFF
--- a/src/instance/defaults.js
+++ b/src/instance/defaults.js
@@ -6,7 +6,7 @@ import TileLayer from 'ol/layer/Tile';
 import OSM from 'ol/source/OSM';
 
 // Import ol-layerswitcher.
-import 'ol-layerswitcher/src/ol-layerswitcher.css';
+import 'ol-layerswitcher/dist/ol-layerswitcher.css';
 import LayerSwitcher from 'ol-layerswitcher';
 
 // Import ol-geocoder.

--- a/src/styles.css
+++ b/src/styles.css
@@ -63,3 +63,6 @@
 .layer-switcher {
   top: 3.5em;
 }
+.layer-switcher.shown {
+  max-height: 300px;
+}


### PR DESCRIPTION
This could also be done in farmOS core.. but it seems sensible to set a default here. It can always be overridden by other CSS.