### PR TITLE
Fix CHANGELOG links in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: |
-            See [CHANGELOG.md](https://github.com/farmOS/farmOS-map/blob/${{ github.ref }}/CHANGELOG.md) for release notes.
+            See [CHANGELOG.md](https://github.com/farmOS/farmOS-map/blob/${{ env.RELEASE_VERSION }}/CHANGELOG.md) for release notes.
           draft: false
           prerelease: false
       - name: Upload Release Asset


### PR DESCRIPTION
The change log links should be like;

> `https://github.com/farmOS/farmOS-map/blob/v1.4.1/CHANGELOG.md`

not as they are now;

> `https://github.com/farmOS/farmOS-map/blob/refs/tags/v1.4.1/CHANGELOG.md`

`actions/create-release` [has code](https://github.com/actions/create-release/blob/4c11c9fe1dcd9636620a16455165783b20fc7ea0/src/create-release.js#L17-L18) to replace the 'refs/tags/' which is what breaks the links.