### PR TITLE
Make geocoder size and positioning more consistent.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -37,9 +37,13 @@
 .ol-geocoder .gcd-gl-control {
   width: 2.4em;
   height: 2.4em;
+  font-size: 1.14em;
 }
 .ol-geocoder .gcd-gl-expanded {
   width: 16em;
+  height: 2.4em;
+}
+.ol-geocoder .gcd-gl-input {
   height: 2.4em;
 }
 
@@ -49,9 +53,10 @@
 }
 .ol-geocoder.gcd-gl-container {
   top: 0.5em;
-  left: 6.5em;
+  left: 7em;
 }
 .ol-geocoder .gcd-gl-input {
+  top: 0.125em;
   left: 3em;
 }
 .ol-edit.ol-control {


### PR DESCRIPTION
Before:
![geocoder_before](https://user-images.githubusercontent.com/3116995/113381748-9ad27b80-9334-11eb-94ed-66a0d54e3d7f.png)

After:
![geocoder_after](https://user-images.githubusercontent.com/3116995/113381816-c9e8ed00-9334-11eb-9d35-01aab06fb962.png)

I also wanted to try and improve the slide transition. Right now it's kinda clunky when the search input first opens, but works fine when closing. There is a CSS transition on the `width` but it also seems that the `position` is changing which might be causing things to jump around. Not 100% sure though.. the best advice I could find from searching was: [Don’t Animate the Width and Height Properties](https://pqina.nl/blog/animating-width-and-height-without-the-squish-effect/), but refactoring to another solution is more work than it's worth (and maybe an upstream change to [ol-geocoder](https://github.com/jonataswalker/ol-geocoder)