### PR TITLE
Fix SnappingGrid so that it actually "snaps"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check in diff of `package.json`/`package-lock.json` from moving to NPM v7
 - Update ssri dependency.
 
+### Fixed
+
+- Fixed broken SnappingGrid snapping
+
 ## [v1.4.2] - 2021-04-02
 
 ### Changed

--- a/src/control/SnappingGrid/SnappingGrid.js
+++ b/src/control/SnappingGrid/SnappingGrid.js
@@ -346,10 +346,10 @@ class SnappingGrid extends Control {
     if (Math.max(otherDrawInteractionLastIdx, otherSnapInteractionLastIdx)
         > ourSnapInteractionLastIdx) {
       // Make sure our snap interaction is always on top of other draw/snap interactions
-      this.getMap().addInteraction(this.gridSnapInteraction);
       if (ourSnapInteractionLastIdx !== -1) {
         mapInteractions.removeAt(ourSnapInteractionLastIdx);
       }
+      this.getMap().addInteraction(this.gridSnapInteraction);
     } else if (otherDrawInteractionLastIdx === -1 && otherSnapInteractionLastIdx === -1) {
       // Remove our snap interaction if there are no other draw/snap interactions
       this.getMap().removeInteraction(this.gridSnapInteraction);


### PR DESCRIPTION
**Why?** Something in the changes between v1.3.0 and
v1.4.0 the SnappingGrid's actual snapping got broken.
I haven't managed to isolate the root cause, what with
the difficulty of rolling back specific dependencies
across NodeJS versions, but I did find what seems to
be a solution.

**What?** When maintaining the SnappingGrid `Snap`
interaction's top-most position in the interaction
stack, it now seems to be important how the stack
modification occurs. This fix changes that such that
the `Snap` interaction is fully removed, then
re-added to the top of the interaction stack.