### PR TITLE
Add a SidePanel control and support for displaying the layer switcher in a pane thereof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update all dependencies.
 
+### Added
+
+- Add a SidePanel control and support for displaying the layer switcher in a pane thereof.
+
 ## [v2.0.0-alpha.0] - 2021-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -388,6 +388,68 @@ myMap.addBehavior('edit', { layer: drawingLayer });
 myMap.addBehavior('measure', { layer: drawingLayer });
 ```
 
+### Side Panel Control
+
+Call `addBehavior('sidePanel')` on the instance returned by
+`farmOS.map.create()` to enable a tabbed side panel.
+
+This will add the SidePanel control to the map instance as `instance.sidePanel`.
+Other behaviors can then define panes and add widgets to those panes using the
+[ol-side-panel API](https://symbioquine.github.io/ol-side-panel/latest/docs/index.html).
+
+```js
+myMap.addBehavior("sidePanel").then(() => {
+  const settingsPane = myMap.sidePanel.definePane({
+    paneId: 'settings',
+    name: 'Settings',
+    icon: '⚙',
+    weight: 101,
+  });
+
+  const scaleLineSettingDiv = el('div', {}, scaleLineSettingDiv => {
+    el('input', {type: "checkbox", id: "showScaleLine", name: "showScaleLine", checked: true}, scaleLineCheckbox => {
+
+      scaleLineCheckbox.addEventListener('change', () => {
+        document.querySelectorAll(".ol-scale-line").forEach(elem => {
+          if (scaleLineCheckbox.checked) {
+            elem.style.display = '';
+          } else {
+            elem.style.display = 'none';
+          }
+        })
+      });
+
+      scaleLineSettingDiv.appendChild(scaleLineCheckbox);
+    });
+    el('label', {'for': 'showScaleLine'}, scaleLineCheckboxLabel => {
+      scaleLineCheckboxLabel.innerHTML = 'Show Scale Line';
+      scaleLineSettingDiv.appendChild(scaleLineCheckboxLabel);
+    });
+  });
+
+  settingsPane.addWidgetElement(scaleLineSettingDiv);
+
+});
+
+// Helper to make defining elements easier
+const el = (tagName, attrs, fn) => {
+  const e = document.createElement(tagName);
+  Object.entries(attrs || {}).forEach(([key, value]) => e.setAttribute(key, value));
+  if (fn) fn(e);
+  return e;
+};
+```
+
+![image](https://user-images.githubusercontent.com/30754460/123672842-a3800400-d7f4-11eb-9697-5e19929b6d2d.png)
+
+### Layer Switcher in the Side Panel
+
+Call `addBehavior('layerSwitcherInSidePanel')` on the instance returned by
+`farmOS.map.create()` to move the layer switcher control into a tab of the side
+panel. This behavior has no effect if the side panel behavior is not enabled.
+
+![image](https://user-images.githubusercontent.com/30754460/123668575-1470ed00-d7f0-11eb-983a-27941772d54b.png)
+
 ### Snapping Grid Controls
 
 Call `addBehavior('snappingGrid')` on the instance returned by

--- a/examples/extended-behavior/static/index.html
+++ b/examples/extended-behavior/static/index.html
@@ -34,6 +34,8 @@
         myMap.edit.wktOn("featurechange", console.log);
         myMap.edit.geoJSONOn("featurechange", console.log);
       });
+      myMap.addBehavior("sidePanel");
+      myMap.addBehavior("layerSwitcherInSidePanel");
       myMap.addBehavior("snappingGrid");
     </script>
   </body>

--- a/examples/simple-html-consumer/static/index.html
+++ b/examples/simple-html-consumer/static/index.html
@@ -33,6 +33,8 @@
         myMap.edit.wktOn("featurechange", console.log);
         myMap.edit.geoJSONOn("featurechange", console.log);
       });
+      myMap.addBehavior("sidePanel");
+      myMap.addBehavior("layerSwitcherInSidePanel");
       myMap.addBehavior("snappingGrid");
     </script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "2.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
+        "bootstrap-icons": "^1.5.0",
         "ol": "^6.5.0",
         "ol-geocoder": "^4.1.2",
         "ol-grid": "^1.1.4",
         "ol-layerswitcher": "^3.7.0",
-        "ol-popup": "^4.0.0"
+        "ol-popup": "^4.0.0",
+        "ol-side-panel": "^1.0.4"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^8.1.1",
@@ -25,6 +27,7 @@
         "eslint-plugin-react": "^7.23.1",
         "mini-css-extract-plugin": "^1.6.0",
         "style-loader": "^0.23.1",
+        "svg-inline-loader": "^0.8.2",
         "webpack": "^5.36.0",
         "webpack-cli": "^4.6.0",
         "webpack-dev-server": "^4.0.0-beta.2"
@@ -1040,6 +1043,14 @@
         "dns-txt": "^2.0.2",
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
+      }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
+      "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/brace-expansion": {
@@ -3707,12 +3718,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/json5/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
@@ -4584,6 +4589,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw=="
+    },
+    "node_modules/ol-side-panel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.4.tgz",
+      "integrity": "sha512-3kPz6w3r8vRu2H9Xu6zjzstmDnU0qG0BeNZF6EzMWukcQfiUqayNwbfAv3z+K47TZQWW6Z3Hn6viBl6h7U3jZA==",
+      "dependencies": {
+        "ol": "^6.5.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -5688,6 +5701,12 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-html-tokenizer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
+      "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=",
+      "dev": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6174,6 +6193,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/svg-inline-loader": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/svg-inline-loader/-/svg-inline-loader-0.8.2.tgz",
+      "integrity": "sha512-kbrcEh5n5JkypaSC152eGfGcnT4lkR0eSfvefaUJkLqgGjRQJyKDvvEE/CCv5aTSdfXuc+N98w16iAojhShI3g==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "simple-html-tokenizer": "^0.1.1"
       }
     },
     "node_modules/table": {
@@ -7839,6 +7869,11 @@
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
       }
+    },
+    "bootstrap-icons": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz",
+      "integrity": "sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9965,14 +10000,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "jsx-ast-utils": {
@@ -10675,6 +10702,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ol-popup/-/ol-popup-4.0.0.tgz",
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw=="
+    },
+    "ol-side-panel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.4.tgz",
+      "integrity": "sha512-3kPz6w3r8vRu2H9Xu6zjzstmDnU0qG0BeNZF6EzMWukcQfiUqayNwbfAv3z+K47TZQWW6Z3Hn6viBl6h7U3jZA==",
+      "requires": {
+        "ol": "^6.5.0"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -11544,6 +11579,12 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-html-tokenizer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
+      "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=",
+      "dev": true
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11948,6 +11989,17 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "svg-inline-loader": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/svg-inline-loader/-/svg-inline-loader-0.8.2.tgz",
+      "integrity": "sha512-kbrcEh5n5JkypaSC152eGfGcnT4lkR0eSfvefaUJkLqgGjRQJyKDvvEE/CCv5aTSdfXuc+N98w16iAojhShI3g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "simple-html-tokenizer": "^0.1.1"
       }
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,18 @@
     "eslint-plugin-react": "^7.23.1",
     "mini-css-extract-plugin": "^1.6.0",
     "style-loader": "^0.23.1",
+    "svg-inline-loader": "^0.8.2",
     "webpack": "^5.36.0",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^4.0.0-beta.2"
   },
   "dependencies": {
+    "bootstrap-icons": "^1.5.0",
     "ol": "^6.5.0",
     "ol-geocoder": "^4.1.2",
     "ol-grid": "^1.1.4",
     "ol-layerswitcher": "^3.7.0",
-    "ol-popup": "^4.0.0"
+    "ol-popup": "^4.0.0",
+    "ol-side-panel": "^1.0.4"
   }
 }

--- a/src/behavior/index.js
+++ b/src/behavior/index.js
@@ -11,7 +11,9 @@ function lazyLoadedBehavior(name) {
 
 export default {
   edit: lazyLoadedBehavior('edit'),
+  layerSwitcherInSidePanel: lazyLoadedBehavior('layerSwitcherInSidePanel'),
   measure: lazyLoadedBehavior('measure'),
   rememberLayer: lazyLoadedBehavior('rememberLayer'),
+  sidePanel: lazyLoadedBehavior('sidePanel'),
   snappingGrid: lazyLoadedBehavior('snappingGrid'),
 };

--- a/src/behavior/layerSwitcherInSidePanel.css
+++ b/src/behavior/layerSwitcherInSidePanel.css
@@ -1,0 +1,7 @@
+.ol-side-panel-pane .layer-switcher {
+  left: 0;
+}
+
+.ol-side-panel-pane .layer-switcher > ul {
+  margin-top: 0;
+}

--- a/src/behavior/layerSwitcherInSidePanel.js
+++ b/src/behavior/layerSwitcherInSidePanel.js
@@ -1,0 +1,59 @@
+import LayerSwitcher from 'ol-layerswitcher';
+
+import layersHalfIcon from 'bootstrap-icons/icons/layers-half.svg';
+
+import './layerSwitcherInSidePanel.css';
+
+// layer switcher in side panel behavior.
+export default {
+  attach(instance) {
+
+    instance.map.getControls().on('add', () => {
+
+      const existingLayerSwitcherControl = instance.map.getControls().getArray()
+        .find(control => typeof control.renderPanel === 'function');
+
+      if (!instance.sidePanel) {
+        return;
+      }
+
+      const existingLayersPane = instance.sidePanel.getPaneById('layers');
+
+      // Only add the layers pane once
+      if (existingLayersPane) {
+        return;
+      }
+
+      const layersPane = instance.sidePanel.definePane({
+        paneId: 'layers',
+        name: 'Layers',
+        icon: layersHalfIcon,
+      });
+
+      const layersDiv = document.createElement('div');
+      layersDiv.classList = 'layer-switcher';
+
+      layersPane.addWidgetElement(layersDiv);
+
+      const renderLayerSwitcher = () => LayerSwitcher.renderPanel(
+        instance.map,
+        layersDiv,
+        { reverse: true },
+      );
+
+      renderLayerSwitcher();
+
+      // When new layers are added, refresh the layer layer switcher
+      instance.map.on('farmOS-map.layer', () => {
+        renderLayerSwitcher();
+      });
+
+      if (existingLayerSwitcherControl) {
+        instance.map.removeControl(existingLayerSwitcherControl);
+      }
+
+    });
+
+  },
+
+};

--- a/src/behavior/sidePanel.css
+++ b/src/behavior/sidePanel.css
@@ -1,0 +1,27 @@
+.ol-side-panel-tabs button svg {
+  margin: 5px;
+  width: 28px;
+}
+
+.ol-side-panel .ol-side-panel-tabs button.active {
+  background-color: #fc3;
+  background-color: rgba(255, 204, 51, 0.7);
+}
+
+.map-with-ol-side-panel .ol-geocoder {
+  margin-left: 100%;
+}
+
+.map-with-ol-side-panel.ol-side-panel-collapsed .ol-geocoder {
+  margin-left: 0;
+}
+
+@media (min-width: 768px) {
+  .map-with-ol-side-panel .ol-geocoder {
+    margin-left: 0;
+  }
+
+  .map-with-ol-side-panel.ol-side-panel-collapsed .ol-geocoder {
+    margin-left: 0;
+  }
+}

--- a/src/behavior/sidePanel.js
+++ b/src/behavior/sidePanel.js
@@ -1,0 +1,18 @@
+// Import ol-side-panel control.
+import 'ol-side-panel/dist/ol-side-panel.css';
+import { SidePanel } from 'ol-side-panel';
+
+import './sidePanel.css';
+
+// Side panel behavior
+export default {
+  attach(instance) {
+
+    // Create the SidePanel control and add it to the map.
+    // Make it available at instance.sidePanel.
+    /* eslint-disable-next-line no-param-reassign */
+    instance.sidePanel = new SidePanel();
+    instance.map.addControl(instance.sidePanel);
+  },
+
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,10 @@ module.exports = {
           { loader: 'css-loader' },
         ],
       },
+      {
+        test: /\.svg$/,
+        loader: 'svg-inline-loader'
+      },
     ],
   },
   plugins: [


### PR DESCRIPTION
**Why?** farmOS-map needs a place to organize extra controls and settings without continuing to clutter the map edges.

Resolves: https://github.com/farmOS/farmOS-map/issues/14