### PR TITLE
Run build on pushes to 2.x branches and related PRs

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,0 +1,22 @@
+name: Run 2.x build
+on:
+  push:
+    branches:
+      - '2.x'
+      - '2.x-**'
+  pull_request:
+    branches:
+      - '2.x'
+
+jobs:
+  build:
+    name: Run build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: '16.x'
+      - run: npm ci
+      - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a SidePanel control and support for displaying the layer switcher in a pane thereof.
 - Add stylelint to ensure css stays more consistent.
+- Run build on pushes to 2.x branches and related PRs.
 
 ## [v2.0.0-alpha.0] - 2021-06-18
 


### PR DESCRIPTION
**Why?** Catch issues earlier in the PR/release process.