### PR TITLE
Fix bug with measure behavior tooltip styling

### DIFF
--- a/src/behavior/measure.css
+++ b/src/behavior/measure.css
@@ -1,0 +1,26 @@
+.ol-tooltip {
+  position: relative;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+  color: white;
+  padding: 4px 8px;
+  opacity: 0.7;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.ol-tooltip-measure {
+  opacity: 1;
+  font-weight: bold;
+}
+
+.ol-tooltip-measure::before {
+  border-top: 6px solid rgba(0, 0, 0, 0.5);
+  border-right: 6px solid transparent;
+  border-left: 6px solid transparent;
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  margin-left: -7px;
+  left: 50%;
+}

--- a/src/behavior/measure.js
+++ b/src/behavior/measure.js
@@ -4,6 +4,8 @@ import Polygon from 'ol/geom/Polygon';
 import { unByKey } from 'ol/Observable';
 import { measureGeometry } from '../utils/measure';
 
+import './measure.css';
+
 // Store measurement overlays keyed by the ID of the feature they measure.
 const measures = {};
 

--- a/src/control/Edit/Edit.css
+++ b/src/control/Edit/Edit.css
@@ -15,30 +15,3 @@
 .ol-edit.ol-control button svg {
   pointer-events: none;
 }
-
-.ol-tooltip {
-  position: relative;
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 4px;
-  color: white;
-  padding: 4px 8px;
-  opacity: 0.7;
-  white-space: nowrap;
-  font-size: 12px;
-}
-
-.ol-tooltip-measure {
-  opacity: 1;
-  font-weight: bold;
-}
-
-.ol-tooltip-measure::before {
-  border-top: 6px solid rgba(0, 0, 0, 0.5);
-  border-right: 6px solid transparent;
-  border-left: 6px solid transparent;
-  content: "";
-  position: absolute;
-  bottom: -6px;
-  margin-left: -7px;
-  left: 50%;
-}


### PR DESCRIPTION
**What?** When the edit behavior is not enabled,
the measure behavior's tooltip styling is missing.

**Expected:**

![expected](https://user-images.githubusercontent.com/30754460/132082793-4deae1e2-e386-4df5-b4df-c6bcd3be75be.png)

**Actual:**

![actual](https://user-images.githubusercontent.com/30754460/132082759-d8dafe2c-19ef-4556-bff9-88fd72c8042c.png)

This is occurring because the measure behavior's tooltip
styling was mixed in with the edit control's styles, which
meant that those styles were only present when the edit behavior's
asset chunks are loaded.

To fix it, this change moves those styles into a new css file and
loads it from the measure behavior.