### PR TITLE
Include css and license in release artifacts.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create artifact
         run: |
-          mkdir ${{ env.RELEASE_VERSION }}-dist && cp dist/farmOS-map.js ${{ env.RELEASE_VERSION }}-dist && zip -r ${{ env.RELEASE_VERSION }}-dist.zip ${{ env.RELEASE_VERSION }}-dist
+          mkdir ${{ env.RELEASE_VERSION }}-dist && cp dist/farmOS-map.* ${{ env.RELEASE_VERSION }}-dist && zip -r ${{ env.RELEASE_VERSION }}-dist.zip ${{ env.RELEASE_VERSION }}-dist
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
Currently `farmOS-map.js` is the only file included in the `version-dist.zip` artifact that is created with releases, but `farmOS-map.css` should be included too. Including the license shouldn't hurt either.

Targeting `dist/farmOS-map.*` will include these three files:

```shell
npm install
npm run build
ls dist/farmOS-map.*
dist/farmOS-map.css  dist/farmOS-map.js  dist/farmOS-map.js.LICENSE.txt
```

This will allow us to reference the release artifact as a composer package instead of using the composer asset-packagist package repository (see https://www.drupal.org/project/farm/issues/3230933)