### PR TITLE
Create release with softprops/action-gh-release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,24 +30,10 @@ jobs:
         run: |
           mkdir ${{ env.RELEASE_VERSION }}-dist && cp dist/farmOS-map* ${{ env.RELEASE_VERSION }}-dist && zip -r ${{ env.RELEASE_VERSION }}-dist.zip ${{ env.RELEASE_VERSION }}-dist
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@6034af24fba4e5a8e975aaa6056554efe4c794d0 #0.1.13
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           body: |
             See [CHANGELOG.md](https://github.com/farmOS/farmOS-map/blob/${{ env.RELEASE_VERSION }}/CHANGELOG.md) for release notes.
+          files: ${{ env.RELEASE_VERSION }}-dist.zip
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./${{ env.RELEASE_VERSION }}-dist.zip
-          asset_name: ${{ env.RELEASE_VERSION }}-dist.zip
-          asset_content_type: application/zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enforce that every pull request includes updates to the CHANGELOG.md (this) file.
 
+### Changed
+
+- Change the Github release workflow to use softprops/action-gh-release v0.1.13.
+
 ## [v2.0.2] - 2021-09-13
 
 ### Fixed


### PR DESCRIPTION
Our Github `release` workflow uses two github actions that were archived in March:

- https://github.com/actions/create-release
- https://github.com/actions/upload-release-asset

https://github.com/softprops/action-gh-release was recommended as a community maintained action. It seemed pretty popular, up to date, and was easy to integrate. Its default values match what we were using previously.
