### PR TITLE
Fixed release workflow to include all built JS/CSS/etc with the "farmOS-map" prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create artifact
         run: |
-          mkdir ${{ env.RELEASE_VERSION }}-dist && cp dist/farmOS-map.* ${{ env.RELEASE_VERSION }}-dist && zip -r ${{ env.RELEASE_VERSION }}-dist.zip ${{ env.RELEASE_VERSION }}-dist
+          mkdir ${{ env.RELEASE_VERSION }}-dist && cp dist/farmOS-map* ${{ env.RELEASE_VERSION }}-dist && zip -r ${{ env.RELEASE_VERSION }}-dist.zip ${{ env.RELEASE_VERSION }}-dist
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed release workflow to include all built JS/CSS/etc with the "farmOS-map" prefix.
+
 ## [v2.0.0] - 2021-09-08
 
 ### Changed


### PR DESCRIPTION
The issue here is that farmOS-map now builds a bunch of JS/CSS chunk files which are necessary for all of farmOS-map's behaviors to work correctly;

```sh
$ ls dist/
farmOS-map-chunk-0111d8061b9a50abef47.css             farmOS-map-chunk-39735a460ef847f90727.js              farmOS-map-chunk-647bd575b50bb76e6f50.js.LICENSE.txt  farmOS-map-chunk-faad37df3b638bef23f7.css
farmOS-map-chunk-089772494e93c03bb076.js              farmOS-map-chunk-39735a460ef847f90727.js.LICENSE.txt  farmOS-map-chunk-72ba8dece6e00934eef6.js              farmOS-map.css
farmOS-map-chunk-089772494e93c03bb076.js.LICENSE.txt  farmOS-map-chunk-3f9ff02a0a072d830cb1.css             farmOS-map-chunk-72ba8dece6e00934eef6.js.LICENSE.txt  farmOS-map.js
farmOS-map-chunk-1035a45deaad9c087345.js              farmOS-map-chunk-5547e19bfe3adbd33a82.css             farmOS-map-chunk-a0608a8045d2ff14b759.js              farmOS-map.js.LICENSE.txt
farmOS-map-chunk-1035a45deaad9c087345.js.LICENSE.txt  farmOS-map-chunk-563e7276f62b25852291.js              farmOS-map-chunk-a0608a8045d2ff14b759.js.LICENSE.txt  index.html
farmOS-map-chunk-13e8e7684df1e30b8f47.js              farmOS-map-chunk-563e7276f62b25852291.js.LICENSE.txt  farmOS-map-chunk-d4168f1434aea493c1b1.css             mapbox.js
farmOS-map-chunk-13e8e7684df1e30b8f47.js.LICENSE.txt  farmOS-map-chunk-5af39167a4e1d678c260.js              farmOS-map-chunk-e19c1353e1d0b55e0be2.js
farmOS-map-chunk-22be7f44929bde3f5135.js              farmOS-map-chunk-5af39167a4e1d678c260.js.LICENSE.txt  farmOS-map-chunk-e19c1353e1d0b55e0be2.js.LICENSE.txt
farmOS-map-chunk-22be7f44929bde3f5135.js.LICENSE.txt  farmOS-map-chunk-647bd575b50bb76e6f50.js              farmOS-map-chunk-f6ac84ea1eeacb673ccc.css
```