### PR TITLE
Fix a race condition in layerSwitcherInSidePanel behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a race condition in the layerSwitcherInSidePanel behavior.
+
 ## [v2.0.1] - 2021-09-08
 
 ### Fixed

--- a/src/behavior/layerSwitcherInSidePanel.js
+++ b/src/behavior/layerSwitcherInSidePanel.js
@@ -8,7 +8,7 @@ import './layerSwitcherInSidePanel.css';
 export default {
   attach(instance) {
 
-    instance.map.getControls().on('add', () => {
+    const tryMovingLayerSwitcherIntoSidePanel = () => {
 
       const existingLayerSwitcherControl = instance.map.getControls().getArray()
         .find(control => typeof control.renderPanel === 'function');
@@ -52,8 +52,12 @@ export default {
         instance.map.removeControl(existingLayerSwitcherControl);
       }
 
-    });
+    };
 
+    // Try moving the layer switcher into the side panel either right away or once
+    // the side panel control is added to the map.
+    tryMovingLayerSwitcherIntoSidePanel();
+    instance.map.getControls().on('add', tryMovingLayerSwitcherIntoSidePanel);
   },
 
 };


### PR DESCRIPTION
**Why?** If the layerSwitcherInSidePanel behavior got attached
after all the other controls were added to the map then it wasn't
taking effect.