### PR TITLE
2.x Update ol side panel and draft v2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.0.2] - 2021-09-13
+
 ### Fixed
 
 - Fixed a race condition in the layerSwitcherInSidePanel behavior.
@@ -291,7 +293,8 @@ I _think_ that's just about everything. :slightly_smiling_face:
 
 Initial commit.
 
-[Unreleased]: https://github.com/farmOS/farmOS-map/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/farmOS/farmOS-map/compare/v2.0.2...HEAD
+[v2.0.2]: https://github.com/farmOS/farmOS-map/compare/v2.0.1...v2.0.2
 [v2.0.1]: https://github.com/farmOS/farmOS-map/compare/v2.0.0...v2.0.1
 [v2.0.0]: https://github.com/farmOS/farmOS-map/compare/v2.0.0-alpha.0...v2.0.0
 [v2.0.0-alpha.0]: https://github.com/farmOS/farmOS-map/compare/v1.4.2...v2.0.0-alpha.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a race condition in the layerSwitcherInSidePanel behavior.
+- Update ol-side-panel to pick up a small bug fix - see [ol-side-panel#1](https://github.com/symbioquine/ol-side-panel/issues/1).
 
 ## [v2.0.1] - 2021-09-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ol-grid": "^1.1.4",
         "ol-layerswitcher": "^3.7.0",
         "ol-popup": "^4.0.0",
-        "ol-side-panel": "^1.0.4"
+        "ol-side-panel": "^1.0.5"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^8.1.1",
@@ -5969,9 +5969,9 @@
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw=="
     },
     "node_modules/ol-side-panel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.4.tgz",
-      "integrity": "sha512-3kPz6w3r8vRu2H9Xu6zjzstmDnU0qG0BeNZF6EzMWukcQfiUqayNwbfAv3z+K47TZQWW6Z3Hn6viBl6h7U3jZA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.5.tgz",
+      "integrity": "sha512-huXQ9ftKTf7Ikp0bECJfRBQDnnhfeAUDDTxEMbt6Qek40Lh/RL5/MfafaJFpgt8TTId70FBlew+XlX6iytRneA==",
       "dependencies": {
         "ol": "^6.5.0"
       }
@@ -13644,9 +13644,9 @@
       "integrity": "sha512-4EMI7+QOAHcPI4RSc2XqEOHgl6922zmk4D1nwuJZsMn3o1qH2IsZg6JggXL+Bm2JmbTQl4dPoZaUZaqSKpm6mw=="
     },
     "ol-side-panel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.4.tgz",
-      "integrity": "sha512-3kPz6w3r8vRu2H9Xu6zjzstmDnU0qG0BeNZF6EzMWukcQfiUqayNwbfAv3z+K47TZQWW6Z3Hn6viBl6h7U3jZA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ol-side-panel/-/ol-side-panel-1.0.5.tgz",
+      "integrity": "sha512-huXQ9ftKTf7Ikp0bECJfRBQDnnhfeAUDDTxEMbt6Qek40Lh/RL5/MfafaJFpgt8TTId70FBlew+XlX6iytRneA==",
       "requires": {
         "ol": "^6.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@farmos.org/farmos-map",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@farmos.org/farmos-map",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "bootstrap-icons": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farmos.org/farmos-map",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OpenLayers map used in farmOS.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ol-grid": "^1.1.4",
     "ol-layerswitcher": "^3.7.0",
     "ol-popup": "^4.0.0",
-    "ol-side-panel": "^1.0.4"
+    "ol-side-panel": "^1.0.5"
   }
 }


### PR DESCRIPTION
This PR is for farmOS-map release v2.0.2 which will include;

### Fixes

- Fixed a race condition in the layerSwitcherInSidePanel behavior.
- Update ol-side-panel to pick up a small bug fix - see [ol-side-panel#1](https://github.com/symbioquine/ol-side-panel/issues/1).