### PR TITLE
Improved styling of layer switcher layer group indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved styling of layer switcher layer group indentation.
+
 ## [v2.0.2] - 2021-09-13
 
 ### Fixed

--- a/src/styles.css
+++ b/src/styles.css
@@ -83,3 +83,7 @@
 .layer-switcher.shown {
   max-height: 300px;
 }
+
+.layer-switcher li.group + li.group {
+  margin-left: 1.2em;
+}


### PR DESCRIPTION
**Why?** It looks a little weird when some of the groups are indented
less than others depending whether they have a checkbox or not.

This is a follow-up to https://github.com/farmOS/farmOS-map/pull/124#issuecomment-901351970

## In separate control

### Before

![image](https://user-images.githubusercontent.com/30754460/133321671-2598892f-5ae7-4c51-ad86-2fe734ab42e8.png)

### After

![image](https://user-images.githubusercontent.com/30754460/133321687-fcf96250-8dad-470d-bc27-d3a1f96653a5.png)

## In side panel

### Before

![image](https://user-images.githubusercontent.com/30754460/133321738-bb950f71-7bdd-4de7-a139-12d12ce95782.png)

### After

![image](https://user-images.githubusercontent.com/30754460/133321752-97915a77-ec46-4ba5-900f-14c7eba6b04c.png)

