### PR TITLE
Avoid useless license files by ensuring they are empty/omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid creating empty license files in the Webpack output by only adding the farmOS-map version banner to the entry-point js files.
+
 ## [v2.0.2] - 2021-09-13
 
 ### Fixed

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,10 @@ module.exports = {
     ],
   },
   plugins: [
-    new webpack.BannerPlugin(`farmOS-map ${info.version}`),
+    new webpack.BannerPlugin({
+      banner: `farmOS-map ${info.version}`,
+      entryOnly: true,
+    }),
     new MiniCssExtractPlugin({
       filename: 'farmOS-map.css',
       chunkFilename: 'farmOS-map-chunk-[contenthash].css',


### PR DESCRIPTION
**Why?** Alternative fix to https://github.com/farmOS/farmOS-map/issues/137

**Before:**

```sh
$ ls dist/
farmOS-map-chunk-1035a45deaad9c087345.js              farmOS-map-chunk-54a6c2fa30f9ee04a341.js.LICENSE.txt  farmOS-map-chunk-a07f228d06bcfd7a3168.js              farmOS-map-chunk-f4eae938edcdeae88d3b.css
farmOS-map-chunk-1035a45deaad9c087345.js.LICENSE.txt  farmOS-map-chunk-563e7276f62b25852291.js              farmOS-map-chunk-a07f228d06bcfd7a3168.js.LICENSE.txt  farmOS-map.css
farmOS-map-chunk-13e8e7684df1e30b8f47.js              farmOS-map-chunk-563e7276f62b25852291.js.LICENSE.txt  farmOS-map-chunk-a817ade2fb1f26951406.css             farmOS-map.js
farmOS-map-chunk-13e8e7684df1e30b8f47.js.LICENSE.txt  farmOS-map-chunk-647bd575b50bb76e6f50.js              farmOS-map-chunk-bf740d1a94ebc0d2ae34.css             farmOS-map.js.LICENSE.txt
farmOS-map-chunk-22be7f44929bde3f5135.js              farmOS-map-chunk-647bd575b50bb76e6f50.js.LICENSE.txt  farmOS-map-chunk-c6cc00ebd9b98bc29a90.css             index.html
farmOS-map-chunk-22be7f44929bde3f5135.js.LICENSE.txt  farmOS-map-chunk-72ba8dece6e00934eef6.js              farmOS-map-chunk-e19c1353e1d0b55e0be2.js              mapbox.js
farmOS-map-chunk-39735a460ef847f90727.js              farmOS-map-chunk-72ba8dece6e00934eef6.js.LICENSE.txt  farmOS-map-chunk-e19c1353e1d0b55e0be2.js.LICENSE.txt
farmOS-map-chunk-39735a460ef847f90727.js.LICENSE.txt  farmOS-map-chunk-a0608a8045d2ff14b759.js              farmOS-map-chunk-e8a93b5be84cf9b8168d.css
farmOS-map-chunk-54a6c2fa30f9ee04a341.js              farmOS-map-chunk-a0608a8045d2ff14b759.js.LICENSE.txt  farmOS-map-chunk-eeb18cd7843f780ff96a.css
$ ls dist/ | wc -l
33
```

**After:**

```sh
$ ls dist/
farmOS-map-chunk-012d94c887bd9ea68319.css  farmOS-map-chunk-550eb1c82599d055186f.js   farmOS-map-chunk-8864685437cdf6dd0160.js  farmOS-map-chunk-df4f076b0132b58967f8.js   farmOS-map-chunk-fd0e93dfff61960387d7.css  index.html
farmOS-map-chunk-15776cf34d32dec9351e.css  farmOS-map-chunk-73306e8efbcf8e8e4e83.css  farmOS-map-chunk-ba7c959328f40f9af066.js  farmOS-map-chunk-e327c19d0417c711d07d.js   farmOS-map.css                             mapbox.js
farmOS-map-chunk-354c79fb56309c47e3db.js   farmOS-map-chunk-7dd7a632da3a071292df.js   farmOS-map-chunk-bf8e0a5697d290a28984.js  farmOS-map-chunk-f3968751da4833031510.css  farmOS-map.js
farmOS-map-chunk-3e8212879c613f957eb8.css  farmOS-map-chunk-7e3bcbbd1dfc56d1b50d.js   farmOS-map-chunk-cba59e1a3c006f856d50.js  farmOS-map-chunk-f47c3d3ac471145a3404.js   farmOS-map.js.LICENSE.txt
$ ls dist/ | wc -l
22
```