### PR TITLE
Enforce that the changelog is updated with every pull request

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Changelog Enforcement Workflow"
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled" since the enforcer allows for skipping enforcement of the changelog being edited via the "skipLabels" property
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    # The checkout step is required since this action uses local git commands to enforce the changelog
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid creating empty license files in the Webpack output by only adding the farmOS-map version banner to the entry-point js files.
 
+### Added
+
+- Enforce that every pull request includes updates to the CHANGELOG.md (this) file.
+
 ## [v2.0.2] - 2021-09-13
 
 ### Fixed


### PR DESCRIPTION
**Why?** It's easy to forget and nice if it happens as part of the
commits which actually make the changes.

See https://github.com/marketplace/actions/changelog-enforcer