### PR TITLE
Decrease popup padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enforce that every pull request includes updates to the CHANGELOG.md (this) file.
+- Add simple example of using the `instance.addPopup` method.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change the Github release workflow to use softprops/action-gh-release v0.1.13.
+- Decrease the popup padding.
 
 ## [v2.0.2] - 2021-09-13
 

--- a/examples/simple-html-consumer/static/index.html
+++ b/examples/simple-html-consumer/static/index.html
@@ -36,6 +36,14 @@
       myMap.addBehavior("sidePanel");
       myMap.addBehavior("layerSwitcherInSidePanel");
       myMap.addBehavior("snappingGrid");
+
+      // Display popup with coordinates when not clicking a feature.
+      myMap.addPopup(function (event) {
+        var feature = myMap.map.forEachFeatureAtPixel(event.pixel, function(feature, layer) { return feature; });
+        if (!feature) {
+          return '<div><h2>Coordinates</h2><p>' + event.coordinate + '</p></div>';
+        }
+      });
     </script>
   </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -83,3 +83,8 @@
 .layer-switcher.shown {
   max-height: 300px;
 }
+
+/* Popup styles. */
+.ol-popup {
+  padding: 0.75em;
+}


### PR DESCRIPTION
In support of https://www.drupal.org/project/farm/issues/3245399. I feel that there is excessive padding around the map popup content. This takes up valuable space when trying to display lots of useful information inside the popup as we are trying to do with the asset `map_popup` view mode in 2.x.

I also added a simple `addPopup` example. If you run the dev example you can inspect the popup and toggle the style to see the changes.

As I mentioned here: https://www.drupal.org/project/farm/issues/3245399#comment-14266498

> I also tacked on a commit to the end of this that decreases the amount of whitespace in the map popup. I think we should consider making that change in the upstream farmOS-map repo itself.

The following styles are the changes I'm referencing. But since `ol-popup-name` is a concept we introduce in farmOS core there is no need to include that change here in farmOS-map.

```
/* Decrease the popup padding. */
.farm-map .ol-popup {
  padding: .75em;
}

/* Remove the popup name margin. */
.farm-map .ol-popup-name {
  margin: 0;
}
```