### PR TITLE
Fix y position of edit controls for small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update openlayers to version 6.14.1.
 
+### Fixed
+
+- Fix y position of edit controls for small screens.
+
 ## [v2.0.3] - 2021-12-08
 
 ### Fixed

--- a/src/control/Edit/Edit.css
+++ b/src/control/Edit/Edit.css
@@ -1,5 +1,4 @@
 .ol-edit.ol-control {
-  top: 8em;
   left: 0.5em;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -69,7 +69,7 @@
 }
 
 .ol-edit.ol-control {
-  top: 5.5em;
+  top: 4.75em;
 }
 
 .ol-rotate.ol-control {


### PR DESCRIPTION
**Why?** On small screens - and the default farmOS layout - the
  controls often overlap or even go off the bottom of the map
  making them hard to use or completely inaccessible.

**Before:**

![image](https://user-images.githubusercontent.com/30754460/162268774-edd7be12-20e7-45be-9312-c4fd16fc1c3a.png)

**After:**

![image](https://user-images.githubusercontent.com/30754460/162268794-d1bf03cf-5215-48f1-806d-283778a99773.png)
