### PR TITLE
Use this.getFeatures() for consistency in edit control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use this.getFeatures() for consistency in edit control. #173
+
 ## [v2.0.7] - 2022-09-22
 
 ### Fixed

--- a/src/control/Edit/Edit.js
+++ b/src/control/Edit/Edit.js
@@ -526,8 +526,7 @@ class Edit extends Control {
    * @api
    */
   getGeoJSON() {
-    const features = this.layer.getSource().getFeatures();
-    return new GeoJSON().writeFeatures(features, projection);
+    return new GeoJSON().writeFeatures(this.getFeatures(), projection);
   }
 
   /**


### PR DESCRIPTION
There is a `getFeatures()` helper function that is not being used here.