### PR TITLE
Allow the public path to be set for Webpack chunk loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow the public path to be set for Webpack chunk loading. #182
+
 ## [v2.0.7] - 2022-09-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -647,6 +647,23 @@ farmOS-map will be accessed at `window.farmOS.map`. Naturally, this requires tha
 and `farmOS-map.css` files are already included in the page as described in the [Usage instructions](#usage)
 above.
 
+### Webpack chunk loading
+
+farmOS-map is bundled using Webpack's [Automatic Public Path](https://webpack.js.org/guides/public-path/#automatic-publicpath)
+configuration to automatically determine the public path used for chunk loading.
+This configuration works most of the time but advanced integrations may need to
+specify a public path for consistent chunk loading [on the fly](https://webpack.js.org/guides/public-path/#on-the-fly).
+
+The public path can be specified by setting `window.farmosMapPublicPath` before
+the `farmOS-map.js` entrypoint is loaded in the DOM. For example:
+
+```html
+<script type="text/javascript">
+  window.farmosMapPublicPath = '/libraries/farmOS-map';
+</script>
+<script src="./farmOS-map.js"></script>
+```
+
 ## Upgrading from farmOS-map 1.x to 2.x
 
 ### For Authors of Custom Behaviors

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+// Assign the public path before other imports.
+import './publicPath';
 import MapInstanceManager from './MapInstanceManager';
 
 // Import the default projection configuration

--- a/src/publicPath.js
+++ b/src/publicPath.js
@@ -1,0 +1,5 @@
+// Allow the public path to be set for Webpack chunk loading.
+if (typeof window.farmosMapPublicPath !== 'undefined') {
+  // eslint-disable-next-line camelcase, no-undef
+  __webpack_public_path__ = window.farmosMapPublicPath;
+}


### PR DESCRIPTION
This is a prerequisite for fixing this farmOS core issue where farmOS-map chunks are not loaded for maps rendered via AJAX: https://www.drupal.org/project/farm/issues/3243922

The trick is that we need to set `__webpack_public_path__` in the farmOS-map entrypoint `main.js`: https://stackoverflow.com/a/51245153. I chose to add this in a separate `publicPath.js` file as recommended by the Webpack [On the fly](https://webpack.js.org/guides/public-path/#on-the-fly) docs (see warning message). This change works when simply added to the top of `main.js` but it raises eslint errors so a separate import makes this cleaner as well.

Added a quick note about this to the "Advanced integrations" section of the README, I'm not sure if we need to include additional details there?