### PR TITLE
Add --farmos-map-accent-color CSS property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--farmos-map-accent-color` CSS property. #186
+
+### Fixed
+
+- Fix color scheme compliance of remaining icons. #181
+
 ### Changed
 
 - Improve interaction and control docs. #185

--- a/README.md
+++ b/README.md
@@ -616,6 +616,16 @@ all the behaviors from `farmOS.map.behaviors` have finished being attached to th
 
 ## Advanced Integration
 
+### Accent color
+
+The farmOS-map accent color can be changed with the `--farmos-map-accent-color` custom CSS property.
+
+```css
+#farm-map {
+  --farmos-map-accent-color: #336633;
+}
+```
+
 ### Working with farmOS-map in an NPM/Webpack Project
 
 Some integration scenarios require farmOS-map to be modeled as a dependency - i.e. so static analysis can

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,14 +1,18 @@
 /* Control color. */
+:root {
+  --farmos-map-accent-color: green;
+}
+
 .ol-control {
   background-color: rgba(255, 255, 255, 0.25);
 }
 
 .ol-control svg {
-  fill: green;
+  fill: var(--farmos-map-accent-color);
 }
 
 .ol-control button {
-  color: green;
+  color: var(--farmos-map-accent-color);
   background-color: rgba(255, 255, 255, 0.8);
 }
 


### PR DESCRIPTION
Fixes #181 

The basic issue here is that we define the `color: green` style in two places. Platforms integrating farmOS-map need to override this CSS in two (in the future, maybe more) places in order to achieve consistent colors.

This introduces the concept of an "accent" color to farmOS-map as a custom CSS property `--farmos-map-accent-color` at the `:root` pseudo-class. I got this idea from Drupal Gin which uses these custom properties quite extensively. The custom CSS property is like a variable that all internal farmOS-map styles should reference. Outside of farmOS-map this variable can be overwritten, ideally at the map wrapper class instead of the global `:root` since custom CSS properties do inherit.

eg following this, for farmOS core we would need to make this change:

```diff
--- a/modules/core/ui/theme/css/map.css
+++ b/modules/core/ui/theme/css/map.css
@@ -1,6 +1,6 @@
 /* Set text color of map control buttons to match SVG color. */
-.farm-map .ol-control button {
-  color: var(--colorGinPrimary);
+.farm-map {
+  --farmos-map-accent-color: var(--colorGinPrimary);
 }
```
More of the spec is here: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties