### PR TITLE
Add loading indicator as default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add loading indicator as default behavior.
 - Add `--farmos-map-accent-color` CSS property. #186
 
 ### Fixed

--- a/src/MapInstanceManager.js
+++ b/src/MapInstanceManager.js
@@ -23,6 +23,7 @@ class MapInstanceManager {
     // Map behaviors which will be automatically attached to all created map
     // instances.
     this.behaviors = {
+      loading: namedBehaviors.loading,
       rememberLayer: namedBehaviors.rememberLayer,
     };
 

--- a/src/behavior/index.js
+++ b/src/behavior/index.js
@@ -12,6 +12,7 @@ function lazyLoadedBehavior(name) {
 export default {
   edit: lazyLoadedBehavior('edit'),
   layerSwitcherInSidePanel: lazyLoadedBehavior('layerSwitcherInSidePanel'),
+  loading: lazyLoadedBehavior('loading'),
   measure: lazyLoadedBehavior('measure'),
   rememberLayer: lazyLoadedBehavior('rememberLayer'),
   sidePanel: lazyLoadedBehavior('sidePanel'),

--- a/src/behavior/loading.css
+++ b/src/behavior/loading.css
@@ -1,0 +1,21 @@
+@keyframes farmos-map-loading-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+div.ol-viewport.loading-spinner::after {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  margin-left: -20px;
+  border-radius: 50%;
+  border: 5px solid rgba(180, 180, 180, 0.6);
+  border-top-color: var(--farmos-map-accent-color);
+  animation: farmos-map-loading-spinner 1s linear infinite;
+}

--- a/src/behavior/loading.js
+++ b/src/behavior/loading.js
@@ -1,0 +1,13 @@
+import './loading.css';
+
+// Loading behavior.
+export default {
+  attach(instance) {
+    instance.map.on('loadstart', () => {
+      instance.map.getViewport().classList.add('loading-spinner');
+    });
+    instance.map.on('loadend', () => {
+      instance.map.getViewport().classList.remove('loading-spinner');
+    });
+  },
+};


### PR DESCRIPTION
This is an initial simple implementation for #97 

I've largely just taken this OL [example](https://openlayers.org/en/latest/examples/load-events.html) and adapted into our code a default named behavior `loading`. It's really quite simple. I think we could expand on this with more complex features described in #97 by using behavior settings eg: `mode: simple/complex`, `progess: true/false`, etc.