### PR TITLE
Provide methods to transform coordinates and extents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Include transform and transformExtent OL methods. #171
+- Add getCurrentViewExtentCoordinates instance function. #171
 
 ## [v2.1.0] - 2022-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include transform and transformExtent OL methods. #171
+
 ## [v2.1.0] - 2022-11-15
 
 ### Added

--- a/src/instance/instance.js
+++ b/src/instance/instance.js
@@ -8,6 +8,7 @@ import defaults from './defaults';
 // Import instance methods.
 import addLayer, { getLayerByName } from './methods/layer';
 import addPopup from './methods/popup';
+import { transform, transformExtent } from './methods/projection';
 import { zoomToVectors, zoomToLayer } from './methods/zoom';
 import { addBehavior, attachBehavior, attachBehaviorsByWeight } from './methods/behavior';
 import { measureGeometry } from '../utils/measure';
@@ -57,6 +58,8 @@ const createInstance = ({ target, options = {} }) => {
     attachBehavior,
     attachBehaviorsByWeight,
     measureGeometry,
+    transform,
+    transformExtent,
   };
 
   return instance;

--- a/src/instance/instance.js
+++ b/src/instance/instance.js
@@ -8,7 +8,7 @@ import defaults from './defaults';
 // Import instance methods.
 import addLayer, { getLayerByName } from './methods/layer';
 import addPopup from './methods/popup';
-import { transform, transformExtent } from './methods/projection';
+import { getCurrentViewExtentCoordinates, transform, transformExtent } from './methods/projection';
 import { zoomToVectors, zoomToLayer } from './methods/zoom';
 import { addBehavior, attachBehavior, attachBehaviorsByWeight } from './methods/behavior';
 import { measureGeometry } from '../utils/measure';
@@ -58,6 +58,7 @@ const createInstance = ({ target, options = {} }) => {
     attachBehavior,
     attachBehaviorsByWeight,
     measureGeometry,
+    getCurrentViewExtentCoordinates,
     transform,
     transformExtent,
   };

--- a/src/instance/methods/projection.js
+++ b/src/instance/methods/projection.js
@@ -1,0 +1,2 @@
+// Export OpenLayers transform functions
+export { transform, transformExtent } from 'ol/proj';

--- a/src/instance/methods/projection.js
+++ b/src/instance/methods/projection.js
@@ -1,2 +1,17 @@
+import { transformExtent } from 'ol/proj';
+
 // Export OpenLayers transform functions
 export { transform, transformExtent } from 'ol/proj';
+
+/**
+ * Returns the map's current view extent in the specified projection coordinates.
+ * @param {import('ol/proj').ProjectionLike} source Source projection-like.
+ *     Defaults to 'EPSG:3857'.
+ * @param {import('ol/proj').ProjectionLike} destination Destination projection-like.
+ *     Defaults to 'EPSG:4326'.
+ * @return {import('ol/extent').Extent} The transformed extent.
+ */
+export function getCurrentViewExtentCoordinates(source = 'EPSG:3857', destination = 'EPSG:4326') {
+  const extent = this.map.getView().calculateExtent(this.map.getSize());
+  return transformExtent(extent, source, destination);
+}


### PR DESCRIPTION
Closes #171 

I also included a simple `getCurrentViewExtentCoordinates(source = 'EPSG:3857', destination = 'EPSG:4326')` helper function. This is only for convenience and is not necessary to include here if `transform` and `transformExtent` are exported with farmOS-map. But it's a simple bit of code and seems like something that may be useful to others. Right now I'm bundling OL and providing this method myself: https://github.com/Regen-Digital/farm_farmlab/blob/1.0.0-beta2/js/farmos-map-extent/main.js#L5-L16