### PR TITLE
Save dist folder to an artifact in run-build.yml workflow.

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -20,3 +20,6 @@ jobs:
           node-version: '16.x'
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Save dist folder to an artifact in run-build.yml workflow. #193
+
 ## [v2.1.0] - 2022-11-15
 
 ### Added


### PR DESCRIPTION
The `run-build.yml` workflow runs on `2.x` and `2.x-**` branches, as well as on `2.x` pull requests. This PR adds an `actions/upload-artifact` step at the end to save the `dist` folder to an artifact at the end of the workflow. This allows you to download the built files and drop them into a local farmOS instance codebase for easy testing, without needing a local farmOS-map development environment.