### PR TITLE
Update ol-geocoder to ^4.3 to fix search results #197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update ol-geocoder to ^4.3 to fix search results. #197
+
 ## [v2.2.1] - 2023-05-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bootstrap-icons": "^1.5.0",
         "ol": "^6.14.1",
-        "ol-geocoder": "^4.1.2",
+        "ol-geocoder": "^4.3.1",
         "ol-grid": "^1.1.7",
         "ol-layerswitcher": "^3.7.0",
         "ol-popup": "^4.0.0",
@@ -6117,9 +6117,12 @@
       }
     },
     "node_modules/ol-geocoder": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/ol-geocoder/-/ol-geocoder-4.1.2.tgz",
-      "integrity": "sha512-QAXpZ04u/hbqjpYOQndN4TSbWyJesqRBLKdRcudILI/FtvvzSGqoJMQ9cnRggCo1tBLR6EXAuwdHH7Zytryrqg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ol-geocoder/-/ol-geocoder-4.3.1.tgz",
+      "integrity": "sha512-058XXp6ZWCkz/g0B/aU1SZeMx/TClxo7Ns7XwbdZ0X/xlwt4XHoyTjsfe2mghg+uaY9olLYllhPD3vq5IRlggw==",
+      "peerDependencies": {
+        "ol": ">=6.0.0"
+      }
     },
     "node_modules/ol-grid": {
       "version": "1.1.7",
@@ -14065,9 +14068,10 @@
       }
     },
     "ol-geocoder": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/ol-geocoder/-/ol-geocoder-4.1.2.tgz",
-      "integrity": "sha512-QAXpZ04u/hbqjpYOQndN4TSbWyJesqRBLKdRcudILI/FtvvzSGqoJMQ9cnRggCo1tBLR6EXAuwdHH7Zytryrqg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ol-geocoder/-/ol-geocoder-4.3.1.tgz",
+      "integrity": "sha512-058XXp6ZWCkz/g0B/aU1SZeMx/TClxo7Ns7XwbdZ0X/xlwt4XHoyTjsfe2mghg+uaY9olLYllhPD3vq5IRlggw==",
+      "requires": {}
     },
     "ol-grid": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "bootstrap-icons": "^1.5.0",
     "ol": "^6.14.1",
-    "ol-geocoder": "^4.1.2",
+    "ol-geocoder": "^4.3.1",
     "ol-grid": "^1.1.7",
     "ol-layerswitcher": "^3.7.0",
     "ol-popup": "^4.0.0",


### PR DESCRIPTION
Updating ol-geocoder solves the issue and geocoding search works again. There are a couple changes that come with this:
1. Search results are no longer autocompleted as you type because this was in violation of Nominatim TOS: https://github.com/Dominique92/ol-geocoder/issues/255#issuecomment-1200202288
2. You must press "Enter" or click the new "return" icon to execute the search.

All other existing functionality continues to work the same: click on a result, and map zooms to that location.

Also want to note that the ol-geocoder library has transition maintainers in the past month and many of these changes have been implemented by the new maintainer. Here is the old repo link that redirects to the new: https://github.com/jonataswalker/ol-geocoder

![ol-geocoder-updated](https://github.com/farmOS/farmOS-map/assets/3116995/5d5b7ea2-60a4-4e80-a0d7-8dd7d3c30c18)
