### PR TITLE
Upgrade open layers to 10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bootstrap-icons": "^1.5.0",
-        "ol": "^10.4.0",
+        "ol": "^10.5.0",
         "ol-geocoder": "^4.3.1",
         "ol-grid": "^2.0.0",
         "ol-layerswitcher": "^4.1.2",
@@ -2038,40 +2038,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "node_modules/color-parse": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      }
-    },
-    "node_modules/color-parse/node_modules/color-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/color-rgba": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-parse": "^2.0.0",
-        "color-space": "^2.0.0"
-      }
-    },
-    "node_modules/color-space": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.1.tgz",
-      "integrity": "sha512-5DJdKYwoDji3ik/i0xSn+SiwXsfwr+1FEcCMUz2GS5speGCfGSbBMOLd84SDUBOuX8y4CvdFJmOBBJuC4wp7sQ==",
-      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "1.2.2",
@@ -6185,14 +6151,12 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "node_modules/ol": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-10.4.0.tgz",
-      "integrity": "sha512-gv3voS4wgej1WVvdCz2ZIBq3lPWy8agaf0094E79piz8IGQzHiOWPs2in1pdoPmuTNvcqGqyUFG3IbxNE6n08g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
-        "color-rgba": "^3.0.0",
-        "color-space": "^2.0.1",
         "earcut": "^3.0.0",
         "geotiff": "^2.1.3",
         "pbf": "4.0.1",
@@ -11285,35 +11249,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "color-parse": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
-      "requires": {
-        "color-name": "^2.0.0"
-      },
-      "dependencies": {
-        "color-name": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-          "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow=="
-        }
-      }
-    },
-    "color-rgba": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "requires": {
-        "color-parse": "^2.0.0",
-        "color-space": "^2.0.0"
-      }
-    },
-    "color-space": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.1.tgz",
-      "integrity": "sha512-5DJdKYwoDji3ik/i0xSn+SiwXsfwr+1FEcCMUz2GS5speGCfGSbBMOLd84SDUBOuX8y4CvdFJmOBBJuC4wp7sQ=="
-    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -14381,13 +14316,11 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "ol": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-10.4.0.tgz",
-      "integrity": "sha512-gv3voS4wgej1WVvdCz2ZIBq3lPWy8agaf0094E79piz8IGQzHiOWPs2in1pdoPmuTNvcqGqyUFG3IbxNE6n08g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
       "requires": {
         "@types/rbush": "4.0.0",
-        "color-rgba": "^3.0.0",
-        "color-space": "^2.0.1",
         "earcut": "^3.0.0",
         "geotiff": "^2.1.3",
         "pbf": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "bootstrap-icons": "^1.5.0",
-    "ol": "^10.4.0",
+    "ol": "^10.5.0",
     "ol-geocoder": "^4.3.1",
     "ol-grid": "^2.0.0",
     "ol-layerswitcher": "^4.1.2",


### PR DESCRIPTION
Building off of #206 just thought I would try to bump us to the next minor release of OL v10.5 - [release notes](https://github.com/openlayers/openlayers/releases/tag/v10.5.0)

This release is mostly just bug fixes but also includes some new features:
> The Snap interaction now allows snapping to segment intersections; it also offers a new unsnap event
> Added getLength method to the MultiLineString geometry class

cc @symbioquine re: snap and @mstenta re: MultiLineString lengths, I think this has been an ongoing feature request? Or maybe I'm thinking area of multiple/complex polygons?